### PR TITLE
Add punk-tinged READMEs for syllabus archive

### DIFF
--- a/ArduinoSculpture/README.md
+++ b/ArduinoSculpture/README.md
@@ -1,0 +1,15 @@
+# Arduino Sculpture (MCAD)
+
+This course mashes up Arduino microcontrollers with sculpture. Students hack together kinetic objects, glitchy artifacts, and interactive installations.
+
+The full code and lesson plans live at [ArduinoSculpture_MCAD](https://github.com/bseverns/ArduinoSculpture_MCAD). Clone it, break it, rebuild it.
+
+## Highlights
+
+- Teaches basic electronics through art-school chaos
+- Encourages rapid prototyping and playful risk-taking
+- Culminates in a final sculpture driven by code
+
+## How to Use
+
+Grab the repo above, read the docs, and adapt it. Feel free to feed back any improvements.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Syllabus Archive
+
+Welcome to the stash. This repo is my messy crate of syllabi and teaching experiments from years of hustling in classrooms.
+
+## What's here?
+
+Right now it's bare bones. The plan: each course gets its own folder with the stuff—syllabi, handouts, oddball assignments. Think of it as a living workbook.
+
+### Courses
+
+- **Arduino Sculpture (MCAD)** — microcontrollers meet molten glue guns. Source lives in its own repo: [ArduinoSculpture_MCAD](https://github.com/bseverns/ArduinoSculpture_MCAD).
+
+More courses will roll in as I rummage through old drives.
+
+## How to Navigate
+
+When a course folder appears, open its README. It'll explain the vibe, outcomes, and how to remix it for your own class.
+
+## Contributing
+
+Snag ideas, fork things, and credit the source. Teaching is better when we share the weird stuff.


### PR DESCRIPTION
## Summary
- introduce top-level README that frames this repo as an evolving cache of teaching material
- add Arduino Sculpture course notes with link out to its dedicated repo

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c740bb4bb48325b67332956023e380