### PR TITLE
Add README roadmap for course archive

### DIFF
--- a/MCADArduinoSculpture/README.md
+++ b/MCADArduinoSculpture/README.md
@@ -1,0 +1,5 @@
+# MCAD Arduino Sculpture
+
+Fragments from my Arduino Sculpture class for MCAD. This folder just holds a local copy of the syllabus (`sc3082_arduino.odt`). The full kit—assignments, code, build notes—lives in a separate repo: <https://github.com/bseverns/ArduinoSculpture_MCAD>.
+
+Clone that, wire up some LEDs, and make your sculptures misbehave.

--- a/MCADMedia1/README.md
+++ b/MCADMedia1/README.md
@@ -1,0 +1,16 @@
+# MCAD Media 1
+
+Foundation-level media art class. The docs here are raw and varied—think assignment sheets, camera cheat guides, and reflections on teaching during chaotic times.
+
+## What's Inside
+- `FA19_FDN 1311 08_Foundation_ Media 1_Severns.docx`: course syllabus.
+- `Pre-Day 1 (Media 1) STUDENTS.pdf`: warm-up survey before day one.
+- `PROJECT____WHY AM I HERE.pdf`: prompt to get students thinking about intent.
+- `m1_PhotoAssignment.pdf` & `Project 2 [photorgaphy] part (b).docx`: photo-based projects.
+- `Media 1_ Project 2 - part 4.docx`: continuation of the photo series.
+- `Media 1 FA20 Assignment 4(abc)_ Audio Mix.docx`: intro to mixing sound.
+- `Media 1 FA21 ASSIGNMENT 3_ Hotglue.docx`: 3D collage using hot glue and found stuff.
+- `Canon Cheat Sheet copy.pdf` & `Sony a6100 Cheat Sheet.pdf`: camera quick guides.
+- `Pedagogy in times of displacement and unrest.docx`: notes on teaching through crisis.
+
+Open, adapt, and twist these for your own foundation students.

--- a/MCADMedia2/MEDIA2-codeEXPLAINERS/README.md
+++ b/MCADMedia2/MEDIA2-codeEXPLAINERS/README.md
@@ -1,0 +1,18 @@
+# MEDIA2 Code Explainers
+
+Tiny p5.js sketches used to demo concepts in Media 2. These are bare-bones, meant for students to tear apart.
+
+| Folder | What's the trick? |
+| --- | --- |
+| `animate2` | swap between two drawings using `frameCount` and custom functions. |
+| `animation` | conditionals that change shapes based on mouse position. |
+| `flexibleParents` | attaching a canvas to a specific DOM element. |
+| `push1` | `push()`/`pop()` drawing states. |
+| `skyler_animate` | student experiment with arrays and random colors. |
+| `snake` | array-powered trailing snake following the mouse. |
+| `video` | play/pause HTML5 video inside p5. |
+| `walking1_2022_02_18_22_43_09` | image layering and DOM text. |
+| `while` / `whileVar` | using `while` loops, with and without color variation. |
+| `whileIRVar` | placeholder for an interactive `while` loop demo (missing sketch). |
+
+Open `index.html` in a browser or run them via the p5 editor.

--- a/MCADMedia2/README.md
+++ b/MCADMedia2/README.md
@@ -1,0 +1,14 @@
+# MCAD Media 2
+
+The sequel to Media 1—more code, more experimentation, more weird. Documentation ranges from project briefs to patch notes for modular synths.
+
+## Highlights
+- `Media 2 SP22 PROJECT 1_ TIME - space.docx`: time-based installation prompt.
+- `Media 2 SP21 PROJECT 2_ Media Fast.docx`: unplug and reflect assignment.
+- `Media 2 SP21 PROJECT 3_ Robot.js.docx`: coding a simple bot.
+- `Media 2 SP21 PROJECT 4_ Orders for the Road.docx`: narrative-driven final.
+- `Walking in the Skyway.docx`: site-specific walking score.
+- `VCV Rack - How it Works (2018-1218).pdf`: modular synthesis cheat sheet.
+- [`MEDIA2-codeEXPLAINERS`](./MEDIA2-codeEXPLAINERS): p5.js demos showing loops, animation, arrays, and other wizardry.
+
+Use these to push students past polite media art.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Syllabus Grab Bag
+
+A messy, honest archive of courses I've slung across classrooms, studios, and half-baked workshops. Each folder is a snapshot of a semester, complete with syllabi, assignments, and weird little experiments. Some files are slick markdown, others are scrappy `.docx` and `.pdf` survivors—open them however you can.
+
+## Map
+- [ExplorationSoundDesign](./ExplorationSoundDesign): complete Chromebook-friendly sound design course with station cards and 22-day lesson run.
+- [MCADArduinoSculpture](./MCADArduinoSculpture): odds and ends from the Arduino Sculpture class. The real action lives in its own repo: <https://github.com/bseverns/ArduinoSculpture_MCAD>.
+- [MCADMedia1](./MCADMedia1): project briefs, cheat sheets, and first-year media experiments.
+- [MCADMedia2](./MCADMedia2): follow-up course with code explainers and project prompts, plus [MEDIA2-codeEXPLAINERS](./MCADMedia2/MEDIA2-codeEXPLAINERS) for p5.js demos.
+
+## Why It Exists
+I hate losing track of good teaching material, so this is my dumping ground. Fork it, remix it, throw it at your students. If something's missing, yell at me or submit a PR.
+
+Stay curious, stay loud.


### PR DESCRIPTION
## Summary
- Add top-level README mapping course archives and link to Arduino Sculpture repo
- Document MCAD Arduino Sculpture, Media 1, and Media 2 folders with teaching intent
- Describe Media 2 code explainer sketches for p5.js demos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7450424e48325aa343e3579dd992b