### PR TITLE
Build shared templates and course briefs

### DIFF
--- a/ExplorationSoundDesign/assessment/rubric.md
+++ b/ExplorationSoundDesign/assessment/rubric.md
@@ -1,0 +1,7 @@
+# Rubric
+Base: [media foundations](../../shared/assessment/rubrics/media-foundations.md)
+
+| Criterion | 4 | 3 | 2 | 1 |
+|---|---|---|---|---|
+| Listening Log | vivid & annotated | complete | partial | none |
+| Final Mix | release-ready | clear | uneven | broken |

--- a/ExplorationSoundDesign/assignments/performance-brief.md
+++ b/ExplorationSoundDesign/assignments/performance-brief.md
@@ -1,0 +1,8 @@
+# Performance Brief
+Blend live field recordings and little synths for a 2–3 minute set.
+
+## Deliverables
+- Recorded performance
+- Process log entry
+
+Assessment: see [rubric](../assessment/rubric.md)

--- a/ExplorationSoundDesign/brief.md
+++ b/ExplorationSoundDesign/brief.md
@@ -1,0 +1,48 @@
+---
+course_id: "exploration-sound-design"
+title: "Exploration: Sound Design"
+level: "HS"
+hours: "22 sessions"
+delivery: "Studio-Seminar"
+keywords: ["sound", "media", "recording"]
+outcomes:
+  - "capture clean audio"
+  - "shape sound through synthesis"
+  - "edit and mix layers"
+  - "critique with peers"
+  - "document process"
+access_notes: "phones, Chromebooks, headphones on hand"
+artifacts: ["syllabus", "final-project", "process-log"]
+lineage: ["community workshop"]
+version: "v0.1"
+updated: "2024-05-29"
+---
+
+## Description
+Mobile-first sound class; make stories with tiny synths and field recordings.
+
+## Outcomes
+- Capture clean audio in the wild
+- Sculpt samples and synth layers
+- Mix with purpose and headroom
+- Give/receive critique in shared vocabulary
+- Track progress in a process log
+
+## Weekly arc
+Week 1 foundations; Week 2 sampling; Week 3 synthesis; Week 4 mixing; Week 5 final project.
+
+## Major assignments
+- [Performance brief](assignments/performance-brief.md)
+- [Process log template](../shared/templates/process-log.md)
+
+## Assessment
+[Course rubric](assessment/rubric.md)
+
+## Access/UDL
+Low-bandwidth modes, loaner gear, flexible timing.
+
+## Policies
+See [AI use](../shared/policies/ai-use.md) and [Consent & Imaging](../shared/policies/consent-and-imaging.md)
+
+## Documentation expectations
+Use a [process log](../shared/templates/process-log.md) and an [assumption ledger](../shared/templates/assumption-ledger.md)

--- a/ExplorationSoundDesign/supports/README.md
+++ b/ExplorationSoundDesign/supports/README.md
@@ -1,0 +1,6 @@
+# Supports
+- [Assignment template](../../shared/templates/assignment.md)
+- [Process log](../../shared/templates/process-log.md)
+- [Assumption ledger](../../shared/templates/assumption-ledger.md)
+- [AI use policy](../../shared/policies/ai-use.md)
+- [Accessibility & UDL](../../shared/policies/accessibility-udl.md)

--- a/MCADArduinoSculpture/assessment/rubric.md
+++ b/MCADArduinoSculpture/assessment/rubric.md
@@ -1,0 +1,7 @@
+# Rubric
+Base: [installation/performance](../../shared/assessment/rubrics/installation-performance.md)
+
+| Criterion | 4 | 3 | 2 | 1 |
+|---|---|---|---|---|
+| Circuit safety | bulletproof | mostly safe | shaky | hazard |
+| Motion clarity | poetic | readable | muddled | absent |

--- a/MCADArduinoSculpture/assignments/kinetic-object.md
+++ b/MCADArduinoSculpture/assignments/kinetic-object.md
@@ -1,0 +1,8 @@
+# Kinetic Object
+Prototype a moving sculpture driven by Arduino and one sensor.
+
+## Deliverables
+- 30–60 sec demo video
+- circuit diagram or fritzing
+
+Assessment: [rubric](../assessment/rubric.md)

--- a/MCADArduinoSculpture/brief.md
+++ b/MCADArduinoSculpture/brief.md
@@ -1,0 +1,48 @@
+---
+course_id: "mcad-arduino-sculpture"
+title: "Arduino Sculpture Lab"
+level: "Undergrad"
+hours: "3 credits"
+delivery: "Lab"
+keywords: ["code", "sculpture", "arduino"]
+outcomes:
+  - "prototype interactive circuits"
+  - "fabricate simple forms"
+  - "program sensors + actuators"
+  - "document iterations"
+  - "critique function and form"
+access_notes: "shops open late; solder carts; quiet build zones"
+artifacts: ["syllabus", "final-project", "process-log"]
+lineage: ["MCAD"]
+version: "v0.1"
+updated: "2024-05-29"
+---
+
+## Description
+Hands-on lab where code animates objects; build kinetic pieces with Arduino.
+
+## Outcomes
+- Wire and code digital/analog pins
+- Fabricate sturdy enclosures
+- Iterate with quick tests
+- Share work-in-progress for critique
+- Log assumptions and power needs
+
+## Weekly arc
+Week 1 basics, Week 2 motion, Week 3 sensors, Week 4 refinement, Week 5 show.
+
+## Major assignments
+- [Kinetic object](assignments/kinetic-object.md)
+- [Process log](../shared/templates/process-log.md)
+
+## Assessment
+[RUBRIC](assessment/rubric.md)
+
+## Access/UDL
+Bench heights varied; captioned demos; flexible deadlines.
+
+## Policies
+[AI use](../shared/policies/ai-use.md), [Safety: soldering](../shared/policies/safety-soldering.md)
+
+## Documentation expectations
+Maintain a [process log](../shared/templates/process-log.md) and [assumption ledger](../shared/templates/assumption-ledger.md)

--- a/MCADArduinoSculpture/supports/README.md
+++ b/MCADArduinoSculpture/supports/README.md
@@ -1,0 +1,6 @@
+# Supports
+- [Assignment template](../../shared/templates/assignment.md)
+- [Process log](../../shared/templates/process-log.md)
+- [Assumption ledger](../../shared/templates/assumption-ledger.md)
+- [AI use](../../shared/policies/ai-use.md)
+- [Safety: soldering](../../shared/policies/safety-soldering.md)

--- a/MCADMedia1/assessment/rubric.md
+++ b/MCADMedia1/assessment/rubric.md
@@ -1,0 +1,7 @@
+# Rubric
+Base: [media foundations](../../shared/assessment/rubrics/media-foundations.md)
+
+| Criterion | 4 | 3 | 2 | 1 |
+|---|---|---|---|---|
+| Sketch volume | prolific | steady | sparse | none |
+| Reflection | incisive | clear | vague | missing |

--- a/MCADMedia1/brief.md
+++ b/MCADMedia1/brief.md
@@ -1,0 +1,47 @@
+---
+course_id: "mcad-media1"
+title: "Media 1"
+level: "Undergrad"
+hours: "3 credits"
+delivery: "Studio-Seminar"
+keywords: ["media", "foundations", "design"]
+outcomes:
+  - "practice visual storytelling"
+  - "experiment across media"
+  - "critique peers constructively"
+  - "document choices"
+  - "prepare for media2"
+access_notes: "loaner kits, low-tech options, predictable cadence"
+artifacts: ["syllabus", "final-project", "process-log"]
+lineage: ["MCAD"]
+version: "v0.1"
+updated: "2024-05-29"
+---
+
+## Description
+Foundations crash-course across media; playful, messy, reflective.
+
+## Outcomes
+- Identify core design elements
+- Produce quick studies in sound, image, and code
+- Iterate with peer feedback
+- Keep a transparent process log
+- Frame intent in short artist notes
+
+## Weekly arc
+Week1 orientation, Week2 image, Week3 sound, Week4 code, Week5 final sprint.
+
+## Major assignments
+- [Why am I here?](finals/why-am-i-here.md)
+
+## Assessment
+[RUBRIC](assessment/rubric.md)
+
+## Access/UDL
+Menu of tools, open lab hours, re-record policies.
+
+## Policies
+[Accessibility](../shared/policies/accessibility-udl.md), [Consent](../shared/policies/consent-and-imaging.md)
+
+## Documentation expectations
+[Process log](../shared/templates/process-log.md) + [Assumption ledger](../shared/templates/assumption-ledger.md)

--- a/MCADMedia1/finals/why-am-i-here.md
+++ b/MCADMedia1/finals/why-am-i-here.md
@@ -1,0 +1,8 @@
+# Why Am I Here?
+Create a 1–2 minute artifact (any medium) on what draws you to media work.
+
+## Deliverables
+- Artifact file or link
+- 100-word reflection
+
+Assessment: [rubric](../assessment/rubric.md)

--- a/MCADMedia1/supports/README.md
+++ b/MCADMedia1/supports/README.md
@@ -1,0 +1,6 @@
+# Supports
+- [Assignment template](../../shared/templates/assignment.md)
+- [Process log](../../shared/templates/process-log.md)
+- [Assumption ledger](../../shared/templates/assumption-ledger.md)
+- [Accessibility & UDL](../../shared/policies/accessibility-udl.md)
+- [Consent & Imaging](../../shared/policies/consent-and-imaging.md)

--- a/MCADMedia2/assessment/rubric.md
+++ b/MCADMedia2/assessment/rubric.md
@@ -1,0 +1,7 @@
+# Rubric
+Base: [code art small](../../shared/assessment/rubrics/code-art-small.md)
+
+| Criterion | 4 | 3 | 2 | 1 |
+|---|---|---|---|---|
+| Data story | razor sharp | clear | loose | off |
+| Broadcast prep | rock solid | usable | needs work | unready |

--- a/MCADMedia2/brief.md
+++ b/MCADMedia2/brief.md
@@ -1,0 +1,47 @@
+---
+course_id: "mcad-media2"
+title: "Media 2: Systems"
+level: "Undergrad"
+hours: "3 credits"
+delivery: "Studio-Seminar"
+keywords: ["systems", "code", "media"]
+outcomes:
+  - "model media systems"
+  - "compose with data"
+  - "deploy interactive pieces"
+  - "collaborate in small teams"
+  - "critique social impact"
+access_notes: "wifi spaces, device checkout, captioned vids"
+artifacts: ["syllabus", "final-project", "process-log"]
+lineage: ["MCAD"]
+version: "v0.1"
+updated: "2024-05-29"
+---
+
+## Description
+Second media studio: code, networks, and a bit of theory.
+
+## Outcomes
+- Diagram media flows
+- Build small browser-based works
+- Iterate using peer tickets
+- Track questions in assumption ledger
+- Present live or async
+
+## Weekly arc
+Week1 recap, Week2 data & APIs, Week3 systems storytelling, Week4 prototype, Week5 broadcast.
+
+## Major assignments
+- [Mountain broadcast](projects/mtn-broadcast-brief.md)
+
+## Assessment
+[RUBRIC](assessment/rubric.md)
+
+## Access/UDL
+Alt paths for offline work; pair programming; transcripts for talks.
+
+## Policies
+[AI use](../shared/policies/ai-use.md) + [Drones](../shared/policies/safety-drones.md)
+
+## Documentation expectations
+[Process log](../shared/templates/process-log.md) and [Assumption ledger](../shared/templates/assumption-ledger.md)

--- a/MCADMedia2/projects/mtn-broadcast-brief.md
+++ b/MCADMedia2/projects/mtn-broadcast-brief.md
@@ -1,0 +1,9 @@
+# Mountain Broadcast Brief
+Small teams stage a micro-cast from a metaphorical mountaintop.
+
+## Deliverables
+- broadcast plan
+- live or recorded stream
+- post-mortem in process log
+
+Assessment: [rubric](../assessment/rubric.md)

--- a/MCADMedia2/supports/README.md
+++ b/MCADMedia2/supports/README.md
@@ -1,0 +1,6 @@
+# Supports
+- [Assignment template](../../shared/templates/assignment.md)
+- [Process log](../../shared/templates/process-log.md)
+- [Assumption ledger](../../shared/templates/assumption-ledger.md)
+- [AI use](../../shared/policies/ai-use.md)
+- [Drones safety](../../shared/policies/safety-drones.md)

--- a/README.md
+++ b/README.md
@@ -12,3 +12,19 @@ A messy, honest archive of courses I've slung across classrooms, studios, and ha
 I hate losing track of good teaching material, so this is my dumping ground. Fork it, remix it, throw it at your students. If something's missing, yell at me or submit a PR.
 
 Stay curious, stay loud.
+
+## Tidy Map
+- [shared/](./shared): templates, policies, rubrics
+- [course-briefs/](./course-briefs): day-one course starters
+- Courses:
+  - [ExplorationSoundDesign](./ExplorationSoundDesign)
+  - [MCADArduinoSculpture](./MCADArduinoSculpture)
+  - [MCADMedia1](./MCADMedia1)
+  - [MCADMedia2](./MCADMedia2)
+
+## How to use
+1. Copy bits from `shared/` into your course folder.
+2. Fill in `brief.md` with the YAML front matter.
+3. Adapt templates, link policies, keep process logs.
+4. Run `python tools/validate.py` to lint and rebuild the catalog.
+5. Check `catalog/index.json` to see your course show up.

--- a/catalog/index.json
+++ b/catalog/index.json
@@ -1,0 +1,65 @@
+[
+  {
+    "course_id": "ai-story-society",
+    "title": "AI, Story & Society",
+    "level": "Mixed",
+    "delivery": "Studio-Seminar",
+    "updated": "2024-05-29"
+  },
+  {
+    "course_id": "mcad-arduino-sculpture",
+    "title": "Arduino Sculpture Lab",
+    "level": "Undergrad",
+    "delivery": "Lab",
+    "updated": "2024-05-29"
+  },
+  {
+    "course_id": "critical-making-civic-media",
+    "title": "Critical Making & Civic Media",
+    "level": "Undergrad",
+    "delivery": "Studio-Seminar",
+    "updated": "2024-05-29"
+  },
+  {
+    "course_id": "digital-storytelling-data-viz",
+    "title": "Digital Storytelling & Data Viz",
+    "level": "Undergrad",
+    "delivery": "Studio-Seminar",
+    "updated": "2024-05-29"
+  },
+  {
+    "course_id": "exploration-sound-design",
+    "title": "Exploration: Sound Design",
+    "level": "HS",
+    "delivery": "Studio-Seminar",
+    "updated": "2024-05-29"
+  },
+  {
+    "course_id": "imaging-otherwise",
+    "title": "Imaging Otherwise",
+    "level": "Undergrad",
+    "delivery": "Studio-Seminar",
+    "updated": "2024-05-29"
+  },
+  {
+    "course_id": "mcad-media1",
+    "title": "Media 1",
+    "level": "Undergrad",
+    "delivery": "Studio-Seminar",
+    "updated": "2024-05-29"
+  },
+  {
+    "course_id": "mcad-media2",
+    "title": "Media 2: Systems",
+    "level": "Undergrad",
+    "delivery": "Studio-Seminar",
+    "updated": "2024-05-29"
+  },
+  {
+    "course_id": "sound-systems-society",
+    "title": "Sound Systems & Society",
+    "level": "HS",
+    "delivery": "Hybrid",
+    "updated": "2024-05-29"
+  }
+]

--- a/catalog/schema.json
+++ b/catalog/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "course_id",
+    "title",
+    "level",
+    "hours",
+    "delivery",
+    "keywords",
+    "outcomes",
+    "access_notes",
+    "artifacts",
+    "lineage",
+    "version",
+    "updated"
+  ],
+  "properties": {
+    "course_id": {"type": "string"},
+    "title": {"type": "string"},
+    "level": {"type": "string"},
+    "hours": {"type": "string"},
+    "delivery": {"type": "string"},
+    "keywords": {"type": "array", "items": {"type": "string"}},
+    "outcomes": {"type": "array", "items": {"type": "string"}},
+    "access_notes": {"type": "string"},
+    "artifacts": {"type": "array", "items": {"type": "string"}},
+    "lineage": {"type": "array", "items": {"type": "string"}},
+    "version": {"type": "string"},
+    "updated": {"type": "string"}
+  }
+}

--- a/course-briefs/ai-story-society.md
+++ b/course-briefs/ai-story-society.md
@@ -1,0 +1,48 @@
+---
+course_id: "ai-story-society"
+title: "AI, Story & Society"
+level: "Mixed"
+hours: "3 credits"
+delivery: "Studio-Seminar"
+keywords: ["ai", "story", "ethics"]
+outcomes:
+  - "interrogate AI narratives"
+  - "co-write with models"
+  - "map societal impacts"
+  - "cite machine collaborators"
+access_notes: "requires accounts, offers offline prompts"
+artifacts: ["syllabus", "final-project", "process-log"]
+lineage: ["critical computing"]
+version: "v0.1"
+updated: "2024-05-29"
+---
+
+## Why
+Because AI writes with or without us; let's steer the pen.
+
+## Outcomes
+- Interrogate AI narratives
+- Co-write with models
+- Map societal impacts
+- Cite machine collaborators
+
+## 2-week starter arc
+- Week1: history and prompt jams
+- Week2: small AI storytelling project
+
+## Assessment mix
+Process log, critique, final zine.
+
+## Reading/media
+- "Atlas of AI" intro
+- "You Look Like a Thing and I Love You"
+- Video: "How DALL·E Works"
+- "The Storytelling Animal" excerpt
+
+## Access notes
+Provide low-bandwidth model options and clear opt-out.
+
+## Artifacts
+- Syllabus
+- Final project
+- Process log

--- a/course-briefs/critical-making-civic-media.md
+++ b/course-briefs/critical-making-civic-media.md
@@ -1,0 +1,48 @@
+---
+course_id: "critical-making-civic-media"
+title: "Critical Making & Civic Media"
+level: "Undergrad"
+hours: "3 credits"
+delivery: "Studio-Seminar"
+keywords: ["civic", "making", "media"]
+outcomes:
+  - "hack public narratives"
+  - "prototype civic tools"
+  - "analyze media power"
+  - "document for replication"
+access_notes: "community partners, low-cost materials"
+artifacts: ["syllabus", "final-project", "process-log"]
+lineage: ["public lab"]
+version: "v0.1"
+updated: "2024-05-29"
+---
+
+## Why
+Make media that pokes the bear and invites neighbors.
+
+## Outcomes
+- Hack public narratives
+- Prototype civic tools
+- Analyze media power
+- Document for replication
+
+## 2-week starter arc
+- Week1: media literacy hacks
+- Week2: quick civic prototypes
+
+## Assessment mix
+Process logs, peer critique, final action.
+
+## Reading/media
+- "Design Justice" intro
+- "Civic Media: Technology, Design, Practice"
+- Episode: "Code Switch" on protest
+- Critical Making zines
+
+## Access notes
+Meet in accessible spaces; provide materials or reimbursement.
+
+## Artifacts
+- Syllabus
+- Final project
+- Process log

--- a/course-briefs/digital-storytelling-data-viz.md
+++ b/course-briefs/digital-storytelling-data-viz.md
@@ -1,0 +1,48 @@
+---
+course_id: "digital-storytelling-data-viz"
+title: "Digital Storytelling & Data Viz"
+level: "Undergrad"
+hours: "3 credits"
+delivery: "Studio-Seminar"
+keywords: ["data", "story", "visualization"]
+outcomes:
+  - "find stories in datasets"
+  - "sketch visual narratives"
+  - "prototype interactive charts"
+  - "credit sources clearly"
+access_notes: "use open data; screen-reader friendly"
+artifacts: ["syllabus", "final-project", "process-log"]
+lineage: ["journalism lab"]
+version: "v0.1"
+updated: "2024-05-29"
+---
+
+## Why
+Numbers have drama; let's stage it.
+
+## Outcomes
+- Find stories in datasets
+- Sketch visual narratives
+- Prototype interactive charts
+- Credit sources clearly
+
+## 2-week starter arc
+- Week1: data scavenger hunt
+- Week2: narrative storyboard + chart prototype
+
+## Assessment mix
+Process log, critique, final viz.
+
+## Reading/media
+- "The Truthful Art"
+- "Information is Beautiful" site
+- "Dear Data" selections
+- Datawrapper tutorials
+
+## Access notes
+Provide CSVs and alt text for visuals.
+
+## Artifacts
+- Syllabus
+- Final project
+- Process log

--- a/course-briefs/imaging-otherwise.md
+++ b/course-briefs/imaging-otherwise.md
@@ -1,0 +1,48 @@
+---
+course_id: "imaging-otherwise"
+title: "Imaging Otherwise"
+level: "Undergrad"
+hours: "3 credits"
+delivery: "Studio-Seminar"
+keywords: ["image", "justice", "experiment"]
+outcomes:
+  - "question visual defaults"
+  - "build alt imaging tools"
+  - "craft speculative visuals"
+  - "share research openly"
+access_notes: "darkroom alt, screen readers supported"
+artifacts: ["syllabus", "final-project", "process-log"]
+lineage: ["critical design"]
+version: "v0.1"
+updated: "2024-05-29"
+---
+
+## Why
+Images shape truth; let's warp them with care.
+
+## Outcomes
+- Question visual defaults
+- Build alt imaging tools
+- Craft speculative visuals
+- Share research openly
+
+## 2-week starter arc
+- Week1: deconstructing camera norms
+- Week2: DIY scanner experiments
+
+## Assessment mix
+Crits, process log, public share-out.
+
+## Reading/media
+- "Against Visual Norms"
+- "Glitch Feminism" intro
+- "Ways of Seeing" episode 1
+- Hydra video toolkit docs
+
+## Access notes
+Quiet viewing rooms; provide tactile diagrams.
+
+## Artifacts
+- Syllabus
+- Final project
+- Process log

--- a/course-briefs/sound-systems-society.md
+++ b/course-briefs/sound-systems-society.md
@@ -1,0 +1,48 @@
+---
+course_id: "sound-systems-society"
+title: "Sound Systems & Society"
+level: "HS"
+hours: "2 credits"
+delivery: "Hybrid"
+keywords: ["sound", "systems", "community"]
+outcomes:
+  - "trace sound system roots"
+  - "mix in community"
+  - "design small PA rigs"
+  - "document gatherings"
+access_notes: "earplugs, remote listening options"
+artifacts: ["syllabus", "final-project", "process-log"]
+lineage: ["after-school"]
+version: "v0.1"
+updated: "2024-05-29"
+---
+
+## Why
+Speakers move people and politics; let's tune both.
+
+## Outcomes
+- Trace sound system roots
+- Mix in community
+- Design small PA rigs
+- Document gatherings
+
+## 2-week starter arc
+- Week1: history and listening party
+- Week2: build tiny system
+
+## Assessment mix
+Participation, mix demo, reflection.
+
+## Reading/media
+- "Bass Culture" excerpt
+- Documentary: "Dub Echoes"
+- Blog: DIY Sound System
+- "Sound System: The Political Power of Music"
+
+## Access notes
+Provide ear protection and remote mixes.
+
+## Artifacts
+- Syllabus
+- Final project
+- Process log

--- a/shared/assessment/participation-guide.md
+++ b/shared/assessment/participation-guide.md
@@ -1,0 +1,5 @@
+# Participation Guide
+- Show up; message if you can't.
+- Contribute and listen.
+- Bring materials, share the air.
+- Respect space and boundaries.

--- a/shared/assessment/rubrics/code-art-small.md
+++ b/shared/assessment/rubrics/code-art-small.md
@@ -1,0 +1,8 @@
+# Code Art (Small) Rubric
+
+| Criterion | 4 | 3 | 2 | 1 |
+|---|---|---|---|---|
+| Interaction | inventive | functional | basic | absent |
+| Code quality | tidy | readable | messy | error-prone |
+| Aesthetics | striking | cohesive | uneven | off |
+| Reflection | sharp | clear | thin | none |

--- a/shared/assessment/rubrics/installation-performance.md
+++ b/shared/assessment/rubrics/installation-performance.md
@@ -1,0 +1,8 @@
+# Installation/Performance Rubric
+
+| Criterion | 4 | 3 | 2 | 1 |
+|---|---|---|---|---|
+| Concept | bold | clear | tentative | unclear |
+| Craft | pro build | stable | shaky | broken |
+| Engagement | audience immersed | engaged | partial | lost |
+| Safety | proactive | compliant | minor issues | risky |

--- a/shared/assessment/rubrics/media-foundations.md
+++ b/shared/assessment/rubrics/media-foundations.md
@@ -1,0 +1,8 @@
+# Media Foundations Rubric
+
+| Criterion | 4 | 3 | 2 | 1 |
+|---|---|---|---|---|
+| Concept | daring & clear | solid | tentative | off |
+| Craft | polished | competent | rough | broken |
+| Documentation | tagged & legible | complete | partial | none |
+| Reflection | insightful | clear | vague | missing |

--- a/shared/assessment/self-and-peer-review.md
+++ b/shared/assessment/self-and-peer-review.md
@@ -1,0 +1,5 @@
+# Self & Peer Review
+- What worked?
+- What could improve?
+- How will you iterate?
+- Peer: offer two stars and a wish.

--- a/shared/policies/accessibility-udl.md
+++ b/shared/policies/accessibility-udl.md
@@ -1,0 +1,5 @@
+# Accessibility & UDL
+- Choice of media for most tasks.
+- Flexible deadlines with check-ins.
+- Alt formats for audio/video.
+- Predictable structures and signposts.

--- a/shared/policies/ai-use.md
+++ b/shared/policies/ai-use.md
@@ -1,0 +1,5 @@
+# AI Use Policy
+- Allowed: brainstorm, drafts with citation.
+- Not allowed: final work without review.
+- Cite AI in the process log: `prompt → tool → how used`.
+- Example: "ChatGPT helped outline section 2."

--- a/shared/policies/consent-and-imaging.md
+++ b/shared/policies/consent-and-imaging.md
@@ -1,0 +1,4 @@
+# Consent & Imaging
+- Opt-in only; default to no-network sharing.
+- Honor delete-now requests.
+- Mind bystanders; get consent or blur.

--- a/shared/policies/safety-drones.md
+++ b/shared/policies/safety-drones.md
@@ -1,0 +1,5 @@
+# Drone Safety
+- Preflight: props tight, battery full.
+- Fly below 400 ft in clear zones.
+- Spotter required; land on warning.
+- Report crashes immediately.

--- a/shared/policies/safety-soldering.md
+++ b/shared/policies/safety-soldering.md
@@ -1,0 +1,5 @@
+# Soldering Safety
+- PPE: eye protection, tied hair, no loose sleeves.
+- Iron in stand; ventilation on.
+- Check tip temp before touching anything.
+- Log incidents and wash hands.

--- a/shared/templates/assignment.md
+++ b/shared/templates/assignment.md
@@ -1,0 +1,30 @@
+# Assignment Template
+
+## Overview
+Brief the task and why it matters.
+
+## Learning goals
+- Skill or concept 1
+- Skill or concept 2
+- Skill or concept 3
+
+## Deliverables
+- What to turn in
+- File or link formats
+
+## Scaffold
+1. Warm-up or sketch
+2. Build / iterate
+3. Share and reflect
+
+## Assessment
+- Criteria used for judging
+- Refer to rubric
+
+## Evidence of learning
+Log in the process log:
+- key decisions
+- links or images
+
+## Access/UDL notes
+Offer format choices, time buffers, and alt paths.

--- a/shared/templates/assumption-ledger.md
+++ b/shared/templates/assumption-ledger.md
@@ -1,0 +1,16 @@
+# Assumption Ledger
+
+## Assumptions
+- what we think is true
+
+## Dependencies
+- things this relies on
+
+## Risks / Unknowns
+- what could go sideways
+
+## Tests / Checks
+- how we'll know
+
+## What would change our minds
+- evidence that flips the plan

--- a/shared/templates/critique-roles.md
+++ b/shared/templates/critique-roles.md
@@ -1,0 +1,6 @@
+# Critique Roles
+- **Translator** – restates the work in plain language.
+- **Cartographer** – maps strengths and gaps.
+- **Steward** – guards the maker's intent.
+- **Instrumentalist** – tests how it performs.
+- **Synthesizer** – threads the comments together.

--- a/shared/templates/documentation-style-guide.md
+++ b/shared/templates/documentation-style-guide.md
@@ -1,0 +1,6 @@
+# Documentation Style Guide
+- **Filenames**: `project-name_author_V01.ext`
+- **Alt text**: describe content and intent.
+- **Versioning**: bump `V##` on significant changes.
+- **Citing AI/tools**: note prompts and tools in log.
+- **Privacy**: blur faces, strip EXIF, get consent.

--- a/shared/templates/entrance-exit-tickets.md
+++ b/shared/templates/entrance-exit-tickets.md
@@ -1,0 +1,11 @@
+# Entrance & Exit Tickets
+
+## Entrance (1 min)
+1. What stuck from last session?
+2. What's one question you bring today?
+3. Name a tool or concept you want to try.
+
+## Exit (1 min)
+1. What did you make or learn?
+2. What still feels fuzzy?
+3. What's your next move?

--- a/shared/templates/process-log.md
+++ b/shared/templates/process-log.md
@@ -1,0 +1,5 @@
+# Process Log
+
+| date | decision | rationale | evidence/link | next step |
+|---|---|---|---|---|
+| | | | | |

--- a/shared/templates/rubric.md
+++ b/shared/templates/rubric.md
@@ -1,0 +1,8 @@
+# Rubric Template
+
+| Criterion | 4 — Exemplary | 3 — Proficient | 2 — Developing | 1 — Missing |
+|---|---|---|---|---|
+| Concept | clear, bold idea | idea holds | idea fuzzy | unclear |
+| Craft/Technique | crisp execution | solid work | rough edges | broken |
+| Documentation | thorough, tagged | complete | partial | absent |
+| Reflection | insightful next steps | clear thoughts | vague | none |

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate course front matter and build catalog."""
+import os, sys, json, re
+from pathlib import Path
+
+SCHEMA_PATH = Path('catalog/schema.json')
+INDEX_PATH = Path('catalog/index.json')
+REQUIRED_SECTIONS = [
+    "Description",
+    "Outcomes",
+    "Weekly arc",
+    "Major assignments",
+    "Assessment",
+    "Access/UDL",
+    "Policies",
+    "Documentation expectations",
+]
+
+
+def load_schema():
+    with SCHEMA_PATH.open() as f:
+        return json.load(f)
+
+
+def parse_simple_yaml(text):
+    data = {}
+    current = None
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith('-') and current:
+            data[current].append(line.split('-',1)[1].strip().strip('"'))
+            continue
+        if ':' in line:
+            key, val = line.split(':',1)
+            key = key.strip()
+            val = val.strip()
+            if val.startswith('[') and val.endswith(']'):
+                items = [i.strip().strip('"') for i in val[1:-1].split(',') if i.strip()]
+                data[key] = items
+            elif val == '' or val is None:
+                data[key] = []
+                current = key
+            else:
+                data[key] = val.strip('"')
+                current = key
+    return data
+
+
+def load_front_matter(path):
+    text = Path(path).read_text(encoding='utf-8')
+    m = re.match(r'^---\n(.*?)\n---', text, re.DOTALL)
+    if not m:
+        raise ValueError(f"{path}: missing front matter")
+    data = parse_simple_yaml(m.group(1))
+    return data, text
+
+
+def validate(data, schema, path):
+    errors = []
+    for key in schema.get('required', []):
+        if key not in data:
+            errors.append(f"{path}: missing {key}")
+    props = schema.get('properties', {})
+    for key, spec in props.items():
+        if key in data:
+            typ = spec.get('type')
+            if typ == 'array' and not isinstance(data[key], list):
+                errors.append(f"{path}: {key} should be list")
+            if typ == 'string' and not isinstance(data[key], str):
+                errors.append(f"{path}: {key} should be string")
+    return errors
+
+
+def check_syllabus(path):
+    warnings = []
+    text = Path(path).read_text(encoding='utf-8')
+    for h in REQUIRED_SECTIONS:
+        if re.search(r'^## +'+re.escape(h)+r'\b', text, re.MULTILINE) is None:
+            warnings.append(f"{path}: missing section '{h}'")
+    if 'process-log' not in text:
+        warnings.append(f"{path}: link to process-log missing")
+    if 'assumption-ledger' not in text:
+        warnings.append(f"{path}: link to assumption-ledger missing")
+    return warnings
+
+
+def main():
+    schema = load_schema()
+    records = []
+    errors = []
+    warnings = []
+
+    for d in sorted(Path('.').iterdir()):
+        if d.is_dir() and (d / 'brief.md').exists():
+            data, _ = load_front_matter(d / 'brief.md')
+            errors.extend(validate(data, schema, str(d / 'brief.md')))
+            records.append({k: data[k] for k in ['course_id','title','level','delivery','updated']})
+            syl = d / 'syllabus.md'
+            if syl.exists():
+                warnings.extend(check_syllabus(syl))
+
+    for md in Path('course-briefs').glob('*.md'):
+        data, _ = load_front_matter(md)
+        errors.extend(validate(data, schema, str(md)))
+        records.append({k: data[k] for k in ['course_id','title','level','delivery','updated']})
+
+    records.sort(key=lambda r: r['title'])
+    INDEX_PATH.write_text(json.dumps(records, indent=2) + '\n', encoding='utf-8')
+
+    for w in warnings:
+        print('WARN:', w, file=sys.stderr)
+    if errors:
+        for e in errors:
+            print('ERROR:', e, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add shared library of templates, policies, and assessment guides
- stub out day-one course briefs with standard front matter
- script to validate front matter and build course catalog

## Testing
- `python tools/validate.py`


------
https://chatgpt.com/codex/tasks/task_e_68c749f9304c8325ae220a1265da63ec