### PR TITLE
Document classroom policies with Corita Kent's rules

### DIFF
--- a/ExplorationSoundDesign/README.md
+++ b/ExplorationSoundDesign/README.md
@@ -67,5 +67,8 @@ Each day has an objective and recommended support cards. The [lessons README](./
 - [S21 — Final Touches & Peer Review](./lessons/s21-final-touches-peer-review.md)
 - [S22 — Showcase & Reflection](./lessons/s22-showcase-reflection.md)
 
+## Policies
+Our classroom vibe riffs on Corita Kent's Ten Rules—skim [shared/policies](../shared/policies) before you spark up the laptops.
+
 ## License
 © /home/sandbox — Educational use permitted; please attribute. Adjust license as needed for your institution.

--- a/ExplorationSoundDesign/lessons/README.md
+++ b/ExplorationSoundDesign/lessons/README.md
@@ -54,3 +54,4 @@ lessons/
 |22 | [S22 — Showcase & Reflection](./s22-showcase-reflection.md) | Export, share, celebrate. | [File Management](../station-cards/file-management.md) |
 
 Take what you need, make noise, repeat.
+And remember: our Corita-fueled [shared policies](../../shared/policies) keep the lab humane.

--- a/ExplorationSoundDesign/station-cards/README.md
+++ b/ExplorationSoundDesign/station-cards/README.md
@@ -24,3 +24,4 @@ station-cards/
 | Troubleshooting | When it all goes sideways, start here. | [troubleshooting.md](./troubleshooting.md) |
 
 Stay scrappy, keep it clean.
+For how we treat each other while patching, scope the [shared policies](../../shared/policies).

--- a/ExplorationSoundDesign/supports/README.md
+++ b/ExplorationSoundDesign/supports/README.md
@@ -4,3 +4,4 @@
 - [Assumption ledger](../../shared/templates/assumption-ledger.md)
 - [AI use policy](../../shared/policies/ai-use.md)
 - [Accessibility & UDL](../../shared/policies/accessibility-udl.md)
+- [Classroom policies (Corita's Ten Rules remix)](../../shared/policies)

--- a/MCADArduinoSculpture/README.md
+++ b/MCADArduinoSculpture/README.md
@@ -2,4 +2,6 @@
 
 Fragments from my Arduino Sculpture class for MCAD. This folder just holds a local copy of the syllabus (`sc3082_arduino.odt`). The full kit—assignments, code, build notes—lives in a separate repo: <https://github.com/bseverns/ArduinoSculpture_MCAD>.
 
+Want the vibe contract? Corita Kent's Ten Rules run the show—see [shared/policies](../shared/policies).
+
 Clone that, wire up some LEDs, and make your sculptures misbehave.

--- a/MCADArduinoSculpture/supports/README.md
+++ b/MCADArduinoSculpture/supports/README.md
@@ -4,3 +4,4 @@
 - [Assumption ledger](../../shared/templates/assumption-ledger.md)
 - [AI use](../../shared/policies/ai-use.md)
 - [Safety: soldering](../../shared/policies/safety-soldering.md)
+- [Classroom policies (Corita's Ten Rules remix)](../../shared/policies)

--- a/MCADMedia1/README.md
+++ b/MCADMedia1/README.md
@@ -14,3 +14,4 @@ Foundation-level media art class. The docs here are raw and varied—think assig
 - `Pedagogy in times of displacement and unrest.docx`: notes on teaching through crisis.
 
 Open, adapt, and twist these for your own foundation students.
+Need the ground rules? Corita Kent's Ten Rules steer us—peek [shared/policies](../shared/policies) before rolling.

--- a/MCADMedia1/supports/README.md
+++ b/MCADMedia1/supports/README.md
@@ -4,3 +4,4 @@
 - [Assumption ledger](../../shared/templates/assumption-ledger.md)
 - [Accessibility & UDL](../../shared/policies/accessibility-udl.md)
 - [Consent & Imaging](../../shared/policies/consent-and-imaging.md)
+- [Classroom policies (Corita's Ten Rules remix)](../../shared/policies)

--- a/MCADMedia2/MEDIA2-codeEXPLAINERS/README.md
+++ b/MCADMedia2/MEDIA2-codeEXPLAINERS/README.md
@@ -16,3 +16,4 @@ Tiny p5.js sketches used to demo concepts in Media 2. These are bare-bones, mean
 | `whileIRVar` | placeholder for an interactive `while` loop demo (missing sketch). |
 
 Open `index.html` in a browser or run them via the p5 editor.
+And yeah, our Corita-drenched [shared policies](../../shared/policies) apply here too.

--- a/MCADMedia2/README.md
+++ b/MCADMedia2/README.md
@@ -12,3 +12,4 @@ The sequel to Media 1—more code, more experimentation, more weird. Documentati
 - [`MEDIA2-codeEXPLAINERS`](./MEDIA2-codeEXPLAINERS): p5.js demos showing loops, animation, arrays, and other wizardry.
 
 Use these to push students past polite media art.
+Before you go rogue, scan the Corita-inspired [shared policies](../shared/policies) we live by.

--- a/MCADMedia2/supports/README.md
+++ b/MCADMedia2/supports/README.md
@@ -4,3 +4,4 @@
 - [Assumption ledger](../../shared/templates/assumption-ledger.md)
 - [AI use](../../shared/policies/ai-use.md)
 - [Drones safety](../../shared/policies/safety-drones.md)
+- [Classroom policies (Corita's Ten Rules remix)](../../shared/policies)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ I hate losing track of good teaching material, so this is my dumping ground. For
 
 Stay curious, stay loud.
 
+Our classroom policies riff on Corita Kent's Ten Rules—check [shared/policies](./shared/policies) if you want the full manifesto.
+
 ## Tidy Map
 - [shared/](./shared): templates, policies, rubrics
 - [course-briefs/](./course-briefs): day-one course starters

--- a/shared/policies/README.md
+++ b/shared/policies/README.md
@@ -1,0 +1,30 @@
+# Policies with a Corita spin
+
+Our classes run on Corita Kent's "Rules for Students and Teachers." Here's the whole score—tuck it somewhere you won't lose it:
+
+1. RULE ONE: Find a place you trust, and then try trusting it for awhile.
+2. RULE TWO: General duties of a student — pull everything out of your teacher; pull everything out of your fellow students.
+3. RULE THREE: General duties of a teacher — pull everything out of your students.
+4. RULE FOUR: Consider everything an experiment.
+5. RULE FIVE: Be self-disciplined — this means finding someone wise or smart and choosing to follow them. To be disciplined is to follow in a good way. To be self-disciplined is to follow in a better way.
+6. RULE SIX: Nothing is a mistake. There’s no win and no fail, there’s only make.
+7. RULE SEVEN: The only rule is work. If you work it will lead to something. It’s the people who do all of the work all of the time who eventually catch on to things.
+8. RULE EIGHT: Don’t try to create and analyze at the same time. They’re different processes.
+9. RULE NINE: Be happy whenever you can manage it. Enjoy yourself. It’s lighter than you think.
+10. RULE TEN: “We’re breaking all the rules. Even our own rules. And how do we do that? By leaving plenty of room for X quantities.” (John Cage)
+
+Hints: Always be around. Come or go to everything. Always go to classes. Read anything you can get your hands on. Look at movies carefully, often. Save everything — it might come in handy later.
+
+## How it plays out here
+
+- 1 is our trust fall: this classroom is the place, keep leaning in.
+- 2 and 3 are our mutual scavenger hunt—grab knowledge from everyone and let them grab from you.
+- 4 lets every assignment be a lab experiment; the mess is part of the lesson.
+- 5 turns discipline into a choice: pick mentors, chase better habits.
+- 6 means flops are just drafts.
+- 7 says grind beats luck, so show up and do the work.
+- 8 reminds us to separate jamming from judging.
+- 9 shouts out joy as a tool; use it whenever it shows up.
+- 10 leaves wiggle room for the unexpected—bend these notes when the moment demands it.
+
+The hints are your survival kit: keep showing up, devour media, and hoard scraps. They'll bail you out more than caffeine ever could.


### PR DESCRIPTION
## Summary
- Add a policy README that quotes Corita Kent's Ten Rules and spins them into classroom norms
- Point the root README and every course doc toward the Corita-inspired policies

## Testing
- `python tools/validate.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74e1dbff48325ac69ae1d845e20ae