### PR TITLE
Expand CTM sound design curriculum docs

### DIFF
--- a/CTMSoundDesign/cue_sheet_template.md
+++ b/CTMSoundDesign/cue_sheet_template.md
@@ -1,7 +1,19 @@
 # Cue Sheet Template — Sound Design for Theater
 
-| Cue # | Description   | Trigger           | Operator | Notes                   |
-|-------|---------------|------------------|----------|-------------------------|
-| Q1    | Thunder roll  | Actor slams door | Jamie    | Fade out after 5 sec    |
-| Q2    | Rain loop     | Lights dim       | Morgan   | Loop until blackout     |
-| Q3    | Blackout hit  | SM call “Go”     | Avery    | End of scene            |
+Duplicate this page for every pod. Keep it open during rehearsals so changes land instantly. Pair it with the stage manager’s script.
+
+| Cue # | Description / Moment                     | Trigger / Call             | Operator | File Name                 | Notes & Levels                          |
+|-------|------------------------------------------|----------------------------|----------|---------------------------|-----------------------------------------|
+| Q1    | Thunder roll under opening monologue     | "Standby Q1… Go" (line 3)  | Jamie    | Show_S1_StormBed.wav      | Fade from -18 dB to -12 dB over 6 sec   |
+| Q2    | Rain loop to cover scene change          | Lights dim to blue wash    | Morgan   | Show_S1_RainLoop.mp3      | Loop until SM calls stop; watch bleed   |
+| Q3    | Blackout hit + door slam                 | SM call “Go”               | Avery    | Show_S1_BlackoutHit.wav   | Verify sub level; cut rain immediately  |
+| Q4    | Ambient city bed for rooftop sequence    | Actor reaches top step     | Jamie    | Show_S2_CityBed.wav       | Start -20 dB, bring up to -14 dB slowly |
+
+### How to Use
+1. **Number cues sequentially** even if you plan to skip them later; crossed-out cues tell the story of revisions.
+2. **Log triggers in stage manager language** (Standby/Go) so anyone can step in and run the stack.
+3. **Track operators**; rotate roles during Sessions 6–8 for redundancy.
+4. **Note mix moves** (levels, fades, loops). Future you will thank present you.
+5. **Cross-link** to assets: drop Drive/QLab links in the Notes column if you’re running hybrid.
+
+Need a printable version? Export this table as PDF and tape it inside the booth. The stage manager should mark matching cues in their script.

--- a/CTMSoundDesign/reflection.md
+++ b/CTMSoundDesign/reflection.md
@@ -1,6 +1,21 @@
 # Reflection Prompts — Sound Design for Theater
 
-- How did sound change the way you felt about the performance?
-- What was hardest about syncing sound with action?
-- How do sound and set design work together to create mood?
-- If you could redo one cue, what would you change and why?
+Use these after Session 8 (or any major rehearsal) to capture honest insights before the adrenaline fades. Pair them with audio snippets or photos when possible.
+
+## Individual Reflection
+1. **Cue Confidence:** Which cue made you sweat the most, and how did you prep for it? Include timestamps or cue numbers.
+2. **Collaboration Check:** How did communication with the stage manager or stagecraft team change over the project?
+3. **Design Impact:** Describe a moment when the sound changed the audience’s reaction. Would you tweak levels, timing, or texture next time?
+4. **Growth Edge:** What skill do you want to steal from the [Exploration Sound Design](../ExplorationSoundDesign/syllabus.md) playbook to level up?
+
+## Team Retro
+1. **Workflow Wins:** What kept your cue sheets, file naming, and backups under control?
+2. **Chaos Moments:** Document any misfires (late cue, wrong level, file missing). How will you prevent the same mess next time?
+3. **Interdisciplinary Moves:** Where did stagecraft or actors influence the sonic choices? Name the collaborators.
+4. **Audience Pulse:** What feedback did you get from peers or the crowd? How does it align with your own assessment from the [Showcase Checklist](./showcase.md)?
+
+## Next Iteration
+- Draft a short action plan (3 bullets) for the next show: new gear to try, cues to redesign, communication habits to keep.
+- Archive reflections alongside cue sheets so future crews inherit your lessons learned.
+
+Reflection isn’t homework fluff—it’s your time to debrief like a pro team. Go deep, be honest, and leave notes your future self will high-five.

--- a/CTMSoundDesign/showcase.md
+++ b/CTMSoundDesign/showcase.md
@@ -1,7 +1,39 @@
-# Showcase Guidelines — Sound Design for Theater
+# Showcase Checklist — Sound Design for Theater
 
-- Length: 2–3 minutes per group.
-- Elements: must include at least one recorded sound, one edited loop, and one live cue.
-- Collaboration: integrate with stagecraft team’s visual design.
-- Tech: students run all cues themselves.
-- Reflection: after the showcase, each group shares one success and one challenge.
+This is the run-of-show blueprint for Session 8. Share with the stagecraft team so everyone knows when to breathe.
+
+## Timeline
+1. **T-48 hours:** Freeze cue edits. Export WAV + MP3 backups, update [Cue Sheet Template](./cue_sheet_template.md).
+2. **T-24 hours:** Full cue-to-cue rehearsal with stagecraft + drama teams. Capture notes in a shared doc.
+3. **Day-of (Call time = 60 minutes before audience):**
+   - Power on playback rig, speakers, comms.
+   - Run a level check for every cue (no audience surprises).
+   - Set up a "quiet hold" zone backstage for last-minute editing if disaster strikes.
+4. **House open:** loop a curated pre-show playlist at -20 dB. Student FOH greeter welcomes guests.
+5. **Performance:** each pod delivers a 2–3 minute scene that includes at least one recorded sound, one edited loop, and one live cue.
+6. **Strike:** archive cues + cue sheets to the class drive, label physical media, reset room.
+
+## Required Elements
+- **Original recordings** captured during the course.
+- **Edited atmospheres/loops** showing layering skills.
+- **Live cue execution** by student operators (no teacher at the board).
+- **Stagecraft integration:** cues align with set pieces, lighting shifts, or prop action.
+
+## Crew Roles
+- **Student Stage Manager:** calls all cues using standby/go language.
+- **Cue Operator(s):** run QLab/Go Button/BandLab session.
+- **Spotter:** watches actors for physical triggers; communicates silently with SM.
+- **Documentarian:** records audio/video snippets for post-show reflection.
+
+## Assessment Touchpoints
+Use this night to gather evidence for the [Assessment & Feedback](./syllabus.md#assessment--feedback) criteria.
+- Capture SM call scripts with annotations.
+- Note any tech hiccups for the reflection debrief.
+- Collect quick audience feedback (two-question exit poll) for student portfolios.
+
+## After the Applause
+- Run the [Reflection Prompts](./reflection.md) within 24 hours while details are fresh.
+- Encourage students to draft a short write-up or audio recap to share with families or on the school site.
+- Archive everything so next year’s crew inherits your momentum.
+
+This showcase is part concert, part lab report. Own the booth, keep it weird, and give the audience a reason to cheer for the techies.

--- a/CTMSoundDesign/syllabus.md
+++ b/CTMSoundDesign/syllabus.md
@@ -1,20 +1,108 @@
+---
+title: "Sound Design for Theater (CTM Collaborative)"
+sessions: 8
+cadence: "1x/week or intensive residency"
+duration_minutes_per_session: 90
+audience: "High school tech theater + media arts students"
+cohort_size: "12–18 students working in pods"
+collaborators: ["Stagecraft/Set Design", "Drama Teacher", "Student Stage Manager"]
+version: "v1.1"
+---
+
 # Sound Design for Theater — Student Syllabus
 
-## Course Overview
-Ever wondered how sound can tell a story? In this course, you’ll step behind the scenes of the theater, learning how to record, edit, and design soundscapes that bring performances to life. Working alongside peers in stagecraft, you’ll create and perform a short showcase where sound and set design meet.
+**Format:** 8 sessions · 90 minutes · integrated with Stagecraft build days  
+**Audience:** Theater tech students who love tinkering with sound, props, and story  
+**Primary tools:** Phones or handheld recorders, laptops with **Audacity** or **BandLab**, PA or powered speakers  
+**Key docs:** [Teacher Quickstart](./teacher_quickstart.md), [Cue Sheet Template](./cue_sheet_template.md), [Showcase Checklist](./showcase.md), [Reflection Prompts](./reflection.md)
 
-## Sessions
-1. Introduction: Sound in Theater — Backstage tour, listening exercises.
-2. Fundamentals of Sound — Pitch, volume, timbre, hands-on demos.
-3. Recording Workshop — Capture backstage and environmental sounds.
-4. Editing & Layering — Use Audacity/BandLab to sculpt your sounds.
-5. Cues & Playback — Learn how sound cues run in a live performance.
-6. Collaboration with Stagecraft — Pair sound with visual design.
-7. Design Sprint — Build your team’s mini performance.
-8. Tech Rehearsal & Showcase — Run the show and reflect.
+---
+
+## Course Promise
+We’re the sonic conspirators behind the show. Across eight scrappy sessions you’ll capture raw textures, sculpt them into cues, and run the board like a pro. The stagecraft crew handles walls and lights; we weaponize silence, drones, and well-timed thunder. By showcase night, you’ll debut a short performance where every cue lands because you built it that way.
 
 ## Learning Outcomes
-- Understand how sound shapes mood and storytelling.
-- Gain basic recording, editing, and playback skills.
-- Work collaboratively across theater disciplines.
-- Present a short performance that integrates sound and set.
+By the final blackout, students will be able to:
+1. **Design intentional sound cues** that reinforce mood, pacing, and story beats for live performance.
+2. **Capture and edit original assets** using field recorders/phones, cleaning noise and balancing levels.
+3. **Coordinate cue playback** with a calling stage manager using standard "standby/go" language.
+4. **Document workflows** with cue sheets, cue stacks, and annotated rehearsal notes.
+5. **Reflect on collaboration** between sound, set, and performance teams, proposing next-iteration tweaks.
+
+## Collaboration Map
+- **Stagecraft build days:** swap assets—sound designers trade recordings for prop textures; stagecraft offers set sketches you can score.
+- **Stage Manager buddy:** assign one student SM per pod to log cues using the [Cue Sheet Template](./cue_sheet_template.md).
+- **Drama teacher:** offers blocking notes; we mirror them with cue timing annotations.
+- **Media crew:** borrow gear tips from the [Exploration Sound Design course](../ExplorationSoundDesign/syllabus.md) if you want deeper synthesis labs.
+
+## Tech & Space Setup
+- **Capture rigs:** smartphones with foam windscreens, one Zoom H4n if available, plus gaffer tape + clips.
+- **Editing stations:** Chromebooks with BandLab (web) or laptops with Audacity + headphones/splitters.
+- **Playback:** QLab, Go Button, or even BandLab stems played via interface—whatever’s reliable. Test with your stage manager before each run.
+- **Room:** carve zones—quiet edit pod, foley pit, cue rehearsal corner with powered speakers.
+
+## Assessment & Feedback
+- **Process journal (30%)** — weekly upload of recordings + screenshots of edits.
+- **Cue readiness (30%)** — clarity of cue sheets, file naming, and rehearsal responsiveness.
+- **Design impact (30%)** — how well sound supports the narrative and stage picture.
+- **Reflection (10%)** — use the [Reflection Prompts](./reflection.md) after showcase night to document wins + fixes.
+
+Feedback cycle: peer walk-throughs each session, SM notes logged directly in cue sheets, final hot wash with stagecraft crew.
+
+---
+
+## Session Roadmap (8×90)
+Each meeting follows **Hook (10) → Mini-lesson (15) → Lab (40) → Collab Rehearsal (20) → Debrief (5)**.
+
+### Session 1 — Sound as Story Spine
+- Listening lab: compare silent vs scored scene clips.
+- Scavenger hunt: record three textures from the theater (door slam, prop scrape, ambient hum).
+- Exit ticket: upload files using `Show_Scene#_Descriptor.wav` naming.
+
+### Session 2 — Editing & Sculpting
+- Mini-lesson: fade, EQ, compression quick hits (borrow slides from [Exploration Sound Design](../ExplorationSoundDesign/syllabus.md#week-3--rhythm-space-and-effects)).
+- Lab: build a 30-second atmosphere bed plus a hard effect.
+- Collab: stagecraft shares set sketches; students pitch sonic motifs for each location.
+
+### Session 3 — Cue Language & Playback
+- Warm-up: call-and-response of standby/go phrasing.
+- Tool focus: QLab or Go Button basics; build a starter cue stack.
+- Pod challenge: align cues with a scripted page from stagecraft. Update [Cue Sheet Template](./cue_sheet_template.md).
+
+### Session 4 — Foley + Live Elements
+- Foley pit: create footsteps, cloth, and impact hits with available props.
+- Capture overhead: mic placement for consistency, ambient capture for loops.
+- Collab rehearsal: run cues while stagecraft tests set changes.
+
+### Session 5 — Syncing with Movement
+- Mini-lesson: tempo mapping, hit points, and tap tempo.
+- Lab: mark cue timings directly on scripts; practice calling cues with a student SM.
+- Debrief: share strategies for communicating during chaos.
+
+### Session 6 — Tech Rehearsal Prep
+- File hygiene: bounce finalized cues, export backup MP3 + WAV, label drives.
+- Run-through: simulate a partial tech rehearsal with lighting cues.
+- Peer critique: trade pods, offer notes using "Keep / Tweak / Kill" frames.
+
+### Session 7 — Full Tech + Fixes
+- Full run with stage manager calling; refine levels and transitions.
+- Emergency drills: what happens when a cue misfires?
+- Update cue sheets + backups; confirm playback rig checklists.
+
+### Session 8 — Showcase & Reflection
+- Performance: each pod presents 2–3 minute scene (see [Showcase Checklist](./showcase.md)).
+- Live mix: rotate cue operators mid-scene to test redundancy.
+- Post-show: journaling using [Reflection Prompts](./reflection.md) + quick share-out with stagecraft partners.
+
+## Extensions & Next Steps
+- Want more studio polish? Bridge into the **Intro to Sound Design & Engineering** curriculum for deeper mixing chops.
+- Document the project as a mini case study in the school newsletter—students create a behind-the-scenes audio blog.
+- Archive cues + cue sheets in a shared drive so next year’s crew starts ahead of the game.
+
+## Appendix: Shared Docs
+- [Teacher Quickstart](./teacher_quickstart.md) — logistics, pre-session checklists, and guest artist ideas.
+- [Cue Sheet Template](./cue_sheet_template.md) — duplicate for each pod.
+- [Showcase Checklist](./showcase.md) — how to run performance night without losing your mind.
+- [Reflection Prompts](./reflection.md) — post-mortem questions to fuel the next iteration.
+
+Welcome to the booth. Bring headphones, curiosity, and the bravery to mute the track when it’s wrong.

--- a/CTMSoundDesign/teacher_quickstart.md
+++ b/CTMSoundDesign/teacher_quickstart.md
@@ -1,21 +1,42 @@
 # Teacher Quickstart Guide — Sound Design for Theater
 
-## Preparation
-- Arrange backstage access and invite sound designer guest if possible.
-- Confirm available tech: recording devices, editing stations, playback software.
-- Prepare cue sheet template for students.
+Welcome to the booth crew. This quickstart is your checklist for keeping eight sessions tight, collaborative, and just the right amount of chaotic.
 
-## Session Highlights
-- Session 1: Use a sound-on/sound-off video clip to spark discussion.
-- Session 3: Send students in pairs to capture Foley sounds (doors, props, footsteps).
-- Session 4: Keep editing goals simple (cut, fade, loop, normalize).
-- Session 5: Practice calling cues with “standby/go” language.
-- Session 7: Coach group roles (recordist, editor, cue operator).
-- Session 8: Treat showcase like a real tech rehearsal — empower students to run their own show.
+## Before Day 1
+- **Survey the space:** map power, cable runs, safe mic zones, and a quiet corner for editing.
+- **Sync with partners:** meet the stagecraft/drama teachers to align on narrative beats and the showcase format.
+- **Gear prep:** charge recorders, label loaner headphones, print scripts, and drop the [Cue Sheet Template](./cue_sheet_template.md) into your shared drive.
+- **Digital hub:** clone a class folder that includes this doc, the [Student Syllabus](./syllabus.md), [Showcase Checklist](./showcase.md), and [Reflection Prompts](./reflection.md).
+- **Guest hype:** invite a local sound designer or the school’s audio tech to speak during Session 3 or 6.
 
-## Resources
+## Weekly Rhythm
+Each session runs on the pattern outlined in the [syllabus](./syllabus.md#session-roadmap-8x90). Keep these anchor moves handy:
+- **Hook:** start with a cinematic moment—muted clip vs. scored clip, or a live cue misfire story.
+- **Mini-lesson:** limit slides to 5–7 minutes; then demo live in the DAW. Reference the [Exploration Sound Design](../ExplorationSoundDesign/syllabus.md) materials when you need deeper dives on EQ/effects.
+- **Lab:** circulate with a stage manager lens—ask "What is this cue serving?" not "Is this a cool sound?"
+- **Collab rehearsal:** tag in the stagecraft instructor. Standby/go language every time.
+- **Debrief:** rapid-fire “Keep / Tweak / Kill” or shout-outs from the booth.
+
+## Spotlight Sessions
+- **Session 2 (Editing):** preload an example project. Have students rebuild the cue after you mute key regions.
+- **Session 3 (Playback):** run a mini mock tech with one group while others observe. Use actual comm headsets if possible.
+- **Session 6 (Tech Prep):** require duplicate exports (WAV + MP3) and a labeled USB or Drive folder before they leave.
+- **Session 8 (Showcase):** assign a student FOH greeter and a student backstage runner so you can stay at the console.
+
+## Troubleshooting
+- **Noise everywhere?** Move the foley pit to the hallway during recording blocks.
+- **Cue sheet chaos?** Midweek, spot-check naming (`Show_Scene#_Cue#.wav`) and color-code critical cues.
+- **Missed cues in rehearsal?** Swap operators mid-run; have the stage manager call cues louder/clearer.
+- **Gear anxiety?** Run Session 0 for volunteers to learn QLab/Go Button basics.
+
+## Resources to Have on Tap
+- [Cue Sheet Template](./cue_sheet_template.md) — duplicate per pod; encourage students to add operator columns.
+- [Showcase Checklist](./showcase.md) — hand this to stagecraft partners so timelines stay synced.
+- [Reflection Prompts](./reflection.md) — build into Session 8 homework.
 - Audacity Manual: https://manual.audacityteam.org/
 - BandLab for Education: https://edu.bandlab.com/
 - QLab Basics: https://qlab.app/docs/v5/
 - BBC Sound Effects Archive: https://sound-effects.bbcrewind.co.uk/
 - Freesound.org: https://freesound.org/
+
+Stick with the plan but don’t fear the punk detour. If a hallway echo inspires a new cue, run with it—just log it in the sheet and keep the crew looped.


### PR DESCRIPTION
## Summary
- expand the CTM Sound Design student syllabus with metadata, collaboration guidance, and detailed session roadmap
- refresh the teacher quickstart plus cue sheet, showcase, and reflection docs with cross-links and actionable checklists
- weave references to Exploration Sound Design materials and emphasize collaboration with stagecraft partners

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cacc4d22408325a2b3e10e38790a5d