### PR TITLE
Refresh top-level README map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
 # Syllabus Grab Bag
 
-A messy, honest archive of courses I've slung across classrooms, studios, and workshops. Each folder is a snapshot of a semester, complete with syllabi, assignments, and weird little experiments. Some files are slick markdown, others are scrappy `.docx` and `.pdf` survivors—open them however you can.
+A messy, honest archive of courses I've slung across classrooms, studios, and workshops. Each folder is a snapshot of a semester,
+complete with syllabi, assignments, and weird little experiments. Some files are slick markdown, others are scrappy `.docx` and
+`.pdf` survivors—open them however you can and remix at will.
 
-## Map
-- [ExplorationSoundDesign](./ExplorationSoundDesign): complete Chromebook-friendly sound design course with station cards and 22-day lesson run.
-- [MCADArduinoSculpture](./MCADArduinoSculpture): odds and ends from the Arduino Sculpture class. The real action lives in its own repo: <https://github.com/bseverns/ArduinoSculpture_MCAD>.
+## How the repo is laid out
+Think of this directory like a teaching studio with stations. Jump in wherever your class needs a spark.
+
+### Course stacks ready to run
+- [CTMSoundDesign](./CTMSoundDesign): cue sheets, reflections, and a quickstart guide for a compact sound unit.
+- [ExplorationSoundDesign](./ExplorationSoundDesign): Chromebook-friendly sound design adventure with station cards and a 22-day arc.
+- [MCADArduinoSculpture](./MCADArduinoSculpture): documentation scraps from my Arduino sculpture class. The canonical repo still lives at <https://github.com/bseverns/ArduinoSculpture_MCAD>.
 - [MCADMedia1](./MCADMedia1): project briefs, cheat sheets, and first-year media experiments.
-- [MCADMedia2](./MCADMedia2): follow-up course with code explainers and project prompts, plus [MEDIA2-codeEXPLAINERS](./MCADMedia2/MEDIA2-codeEXPLAINERS) for p5.js demos.
+- [MCADMedia2](./MCADMedia2): follow-up course with code explainers and project prompts, including [MEDIA2-codeEXPLAINERS](./MCADMedia2/MEDIA2-codeEXPLAINERS) for p5.js demos.
+- [Robotics-to-FPV-Course](./Robotics-to-FPV-Course): full robotics-to-FPV pathway with build plans, assessments, safety docs, and sim exercises.
 
-## Why It Exists
-I hate losing track of good teaching material, so this is my dumping ground. Fork it, remix it, throw it at your students. If something's missing, yell at me or submit a PR.
+### Resource bins and shared infrastructure
+- [shared/](./shared): policies, assessment tools, and templates grounded in Corita Kent's Ten Rules.
+- [catalog/](./catalog): JSON index + schema for wrangling these courses into something a little more machine-readable.
+- [tools/](./tools): utility scripts for validating the catalog and keeping data honest.
 
-Our classroom policies riff on Corita Kent's Ten Rules—check [shared/policies](./shared/policies) if you want the full manifesto.
+### Future courses + reference piles
+- [future-course-briefs/](./future-course-briefs): rough briefs and provocations for classes still percolating.
+- [SMM/](./SMM) & [MPS_comEd/](./MPS_comEd): legacy lesson plans hanging out as `.docx` files—convert, annotate, or cannibalize them.
 
-## Tidy Map
-- [shared/](./shared): templates, policies, rubrics
-- [course-briefs/](./course-briefs): day-one course starters
-- Courses I have cataloged so far:
-  - [ExplorationSoundDesign](./ExplorationSoundDesign)
-  - [MCADArduinoSculpture](./MCADArduinoSculpture)
-  - [MCADMedia1](./MCADMedia1)
-  - [MCADMedia2](./MCADMedia2)
+## Why it exists
+I hate losing track of good teaching material, so this is my dumping ground. Fork it, remix it, throw it at your students. If
+something's missing, yell at me or submit a PR.
 
-Do work with these things as you will. Share freely.
+Want the full classroom manifesto? Hit [shared/policies](./shared/policies) for expectations riffing on Corita Kent's Ten Rules.
+
+## How to work with this stash
+- Start with a course stack, then raid `shared/` for rubrics or policies to glue it together.
+- Use the JSON `catalog/` when you want to surface courses on a website or in another tool—`tools/validate.py` keeps you from breaking it.
+- Everything is remixable. Annotate, translate, break, rebuild. Just send back the cool stuff.


### PR DESCRIPTION
## Summary
- reorganize the root README to match the current directory layout
- highlight active course bundles, shared resources, and future-course notes
- add quick guidance on how to remix the materials and use the catalog tooling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2f7c5e6c88325b737b62bb491d66b