### PR TITLE
Relocate Digital-Music-Control into sound index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,56 @@
 # Syllabus Grab Bag
 
-A messy, honest archive of courses I've slung across classrooms, studios, and workshops. Each folder is a snapshot of a semester,
-complete with syllabi, assignments, and weird little experiments. Some files are slick markdown, others are scrappy `.docx` and
-`.pdf` survivors—open them however you can and remix at will.
+A messy, honest archive of courses I've slung across classrooms, studios, and workshops. Every folder is a snapshot—some are fully-scaffolded semester arcs, others are raw `.docx` survivors begging for a remix. Treat this place like a half-studio notebook, half-teaching zine. Grab what you need, annotate the margins, and throw it back when you make it better.
 
-## How the repo is laid out
-Think of this directory like a teaching studio with stations. Jump in wherever your class needs a spark.
+## How to navigate the chaos
+- **Clone it, then zoom in.** Most course folders ship with their own README or syllabus map. Follow those breadcrumbs before spelunking blindly.
+- **Work from the inside out.** Lesson plans live alongside assessments, checklists, slicer profiles, BandLab station cards—you name it. When in doubt, open `syllabus/` first, then chase `lessons/`, `activities/`, or `sessions/`.
+- **Mind the licenses.** Content is largely CC BY 4.0, code leans MIT. Check each folder before you publish or commercialize.
+- **Keep notes scrappy.** I leave space for “local hacks” in most docs. Track your tweaks; future-you (or future-me) will thank you.
 
-### Course stacks ready to run
-- [CTMSoundDesign](./CTMSoundDesign): cue sheets, reflections, and a quickstart guide for a compact sound unit.
-- [ExplorationSoundDesign](./ExplorationSoundDesign): Chromebook-friendly sound design adventure with station cards and a 22-day arc.
-- [MCADArduinoSculpture](./MCADArduinoSculpture): documentation scraps from my Arduino sculpture class. The canonical repo still lives at <https://github.com/bseverns/ArduinoSculpture_MCAD>.
-- [MCADMedia1](./MCADMedia1): project briefs, cheat sheets, and first-year media experiments.
-- [MCADMedia2](./MCADMedia2): follow-up course with code explainers and project prompts, including [MEDIA2-codeEXPLAINERS](./MCADMedia2/MEDIA2-codeEXPLAINERS) for p5.js demos.
-- [Robotics-to-FPV-Course](./Robotics-to-FPV-Course): full robotics-to-FPV pathway with build plans, assessments, safety docs, and sim exercises.
+## Course kits — digital fabrication & making
+- [3D-Printing-Course-3-5](./3D-Printing-Course-3-5) – 11-week elementary pipeline from imagination to MakerBot SKETCH queue, complete with print ops, slicer profiles, and empathy-driven capstones.
+- [Design-for-Printability-and-Function](./Design-for-Printability-and-Function) – Intermediate CAD + printability bootcamp for grades 7–9 with OpenSCAD test artifacts, tolerance labs, and data templates for strength tests.
+- [Engineering-Challenges](./Engineering-Challenges) – Mechanism gauntlet (gears, cams, compliant hinges) with print-ready rigs, rubrics, and A/B block lessons targeting measurable performance wins.
+- [Advanced-DigiFab-Lab-Multimaterial-Scanning-Gcode](./Advanced-DigiFab-Lab-Multimaterial-Scanning-Gcode) – Capstone lab where students run a multi-printer fleet, swap filaments mid-job, parse G-code, and process 3D scans like junior techs.
+- [Art-Sculpture-Parametric-3D-Print](./Art-Sculpture-Parametric-3D-Print) – Parametric sculpture studio leaning on OpenSCAD, p5.js, and printer weirdness (vase mode, translucency) to treat rules as art material.
+- [digital_manufacturing](./digital_manufacturing) – 12-session studio weaving CNC, slicing, and CAM literacy with ready-to-run Cubiko G-code, Cura profiles, and printable workflow posters.
+- [MCADArduinoSculpture](./MCADArduinoSculpture) – Local mirror of my Arduino Sculpture syllabus; full build kits and code live in the upstream repo for deeper dives.
 
-### Resource bins and shared infrastructure
-- [shared/](./shared): policies, assessment tools, and templates grounded in Corita Kent's Ten Rules.
-- [catalog/](./catalog): JSON index + schema for wrangling these courses into something a little more machine-readable.
-- [tools/](./tools): utility scripts for validating the catalog and keeping data honest.
+## Course kits — robotics, flight & control
+- [Robotics-to-FPV-Course](./Robotics-to-FPV-Course) – 15-week bridge from Arduino ground robots to sub-250 g FPV whoops, with BOMs, flight checklists, and simulator drills to keep teams flying smart.
+- [HS_Drone_Racing_League](./HS_Drone_Racing_League) – League starter kit covering safety law, bootcamp schedules, forms, and sim training for school-based FPV crews.
+- [TinyWhoop-Workshop](./TinyWhoop-Workshop) – Four-session Betaflight configurator workshop emphasizing safe habits, backups, and tuning tiny whoops until they feel personal.
+- [Robotics_HS_SpikePrime](./Robotics_HS_SpikePrime) – Compact 12-hour Spike Prime primer with `.md` and `.pdf` guides for quick-start robotics programs.
+- [robotic-vibes](./robotic-vibes) – Expanding course family built on a robotics + vibe coding level 1 spine, offering LEGO Spike, Arduino, and CircuitPython dialects with reproducible build docs and assessment kits.
 
-### Future courses + reference piles
-- [future-course-briefs/](./future-course-briefs): rough briefs and provocations for classes still percolating.
-- [SMM/](./SMM) & [MPS_comEd/](./MPS_comEd): legacy lesson plans hanging out as `.docx` files—convert, annotate, or cannibalize them.
+## Course kits — sound, media & critical listening
+- [CTMSoundDesign](./CTMSoundDesign) – Quick-start cue sheets, reflections, and a compact eight-session syllabus anchored in making, rehearsing, and critiquing sound cues for theater.
+- [ExplorationSoundDesign](./ExplorationSoundDesign) – 22-day Chromebook-friendly sound design adventure with BandLab station cards, lessons, and assessments built for mobile-first classrooms.
+- [Digital-Music-Control](./Digital-Music-Control) – MOARkNOBS-inspired MIDI controller curriculum across maker vs. studio tracks, guiding learners from Arduino blinks to firmware architecture and performance UX.
+- [SoundSystemsSociety](./SoundSystemsSociety) – College-level seminar where PA systems meet politics, complete with assignments, listening logs, and instructor notes for power-aware sound practice.
 
-## Why it exists
-I hate losing track of good teaching material, so this is my dumping ground. Fork it, remix it, throw it at your students. If
-something's missing, yell at me or submit a PR.
+## Course kits — imaging, media art & storytelling
+- [digital-imaging-lab](./digital-imaging-lab) – Middle/early high school imaging lab treating pixels as craft and inquiry, with session plans, anchor projects, rubrics, and ethics resources.
+- [ImagingOtherwise](./ImagingOtherwise) – Undergraduate studio-seminar challenging visual defaults through speculative imaging assignments, readings, and instructor pacing notes.
+- [MCADMedia1](./MCADMedia1) – Foundation media archive stuffed with assignment sheets, camera cheats, and pandemic-era pedagogy reflections for remixing first-year experiences.
+- [MCADMedia2](./MCADMedia2) – Sequel course docs spanning experimental media briefs, modular synth cheat sheets, and p5.js explainers to push students past polite work.
 
-Want the full classroom manifesto? Hit [shared/policies](./shared/policies) for expectations riffing on Corita Kent's Ten Rules.
+## Workshops, briefs & experiments
+- [diy-local-ai-workshop](./diy-local-ai-workshop) – Three-hour agency-first workshop guiding adults through local LLM installs, tooling choices, and prompt boundaries they can defend.
 
-## How to work with this stash
-- Start with a course stack, then raid `shared/` for rubrics or policies to glue it together.
-- Use the JSON `catalog/` when you want to surface courses on a website or in another tool—`tools/validate.py` keeps you from breaking it.
-- Everything is remixable. Annotate, translate, break, rebuild. Just send back the cool stuff.
+> Want to braid sound and control? Start with **Digital-Music-Control** and riff into **CTMSoundDesign** or **ExplorationSoundDesign**—the sections above spell out how.
+
+## Legacy docs & loose artifacts
+- [MPS_comEd](./MPS_comEd) – Early community education lesson plans and class descriptions straight from the archives—expect `.docx` time capsules.
+- [SMM](./SMM) – Miscellaneous workshop docs like chain-reaction mini builds and digital photo briefs from past programs.
+
+## Meta: indexing, validation & data
+- [catalog](./catalog) – JSON index + schema pairing for folks who want to surface these courses in another system; validate before you broadcast.
+
+## Contribute like a punk archivist
+- Fork, remix, and PR your local variants. Include what changed, why, and how it landed in class.
+- Drop annotations inside docs rather than rewriting from scratch when possible—it keeps the lineage intact.
+- When you add a new course, copy an existing folder structure that fits and document the **intent** first, not just the assets.
+
+> Keep it generous, cite your sources, and let the students co-author the next version.


### PR DESCRIPTION
## Summary
- move the Digital-Music-Control course link from the robotics roster into the sound, media & critical listening section

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f69291f2483258c041628493fa69f)