### PR TITLE
Add snapshot headers to in-progress course drafts

### DIFF
--- a/in-progress/ai-story-society.md
+++ b/in-progress/ai-story-society.md
@@ -17,6 +17,22 @@ version: "v0.1"
 updated: "2024-05-29"
 ---
 
+## Snapshot
+**Working title:** AI, Story & Society  
+**Intended level:** POST_SECONDARY  
+**Estimated hours:** 45 (3 credits)  
+**Learning outcomes:**
+- Interrogate AI narratives in culture and policy.
+- Co-write with models and document the collaboration.
+- Map societal impacts across labor, bias, and power.
+- Cite machine collaborators and data sources with care.
+
+**What’s missing:**
+- [ ] Week-by-week schedule
+- [ ] Assignment briefs + deliverables
+- [ ] Assessment rubric
+- [ ] Tooling/access plan
+
 ## Why
 Because AI writes with or without us; let's steer the pen.
 

--- a/in-progress/critical-making-civic-media.md
+++ b/in-progress/critical-making-civic-media.md
@@ -17,6 +17,22 @@ version: "v0.1"
 updated: "2024-05-29"
 ---
 
+## Snapshot
+**Working title:** Critical Making & Civic Media  
+**Intended level:** POST_SECONDARY  
+**Estimated hours:** 45 (3 credits)  
+**Learning outcomes:**
+- Hack public narratives with tactical media prototypes.
+- Prototype civic tools that serve real community needs.
+- Analyze media power, bias, and institutional friction.
+- Document builds so others can replicate and remix.
+
+**What’s missing:**
+- [ ] Week-by-week schedule
+- [ ] Assignment briefs + deliverables
+- [ ] Assessment rubric
+- [ ] Partner onboarding checklist
+
 ## Why
 Make media that pokes the bear and invites neighbors.
 

--- a/in-progress/digital-storytelling-data-viz.md
+++ b/in-progress/digital-storytelling-data-viz.md
@@ -17,6 +17,22 @@ version: "v0.1"
 updated: "2024-05-29"
 ---
 
+## Snapshot
+**Working title:** Digital Storytelling & Data Viz  
+**Intended level:** POST_SECONDARY  
+**Estimated hours:** 45 (3 credits)  
+**Learning outcomes:**
+- Find stories in datasets and frame their stakes.
+- Sketch visual narratives that guide reader attention.
+- Prototype interactive charts with accessible defaults.
+- Credit sources clearly and track data provenance.
+
+**What’s missing:**
+- [ ] Week-by-week schedule
+- [ ] Assignment briefs + deliverables
+- [ ] Assessment rubric
+- [ ] Dataset sourcing plan
+
 ## Why
 Numbers have drama; let's stage it.
 


### PR DESCRIPTION
### Motivation
- Make the three in-progress course drafts immediately navigable and adoptable by adding a compact metadata/README snapshot at the top. 
- Surface working title, intended level, estimated hours, learning outcomes, and a short “what’s missing” checklist so instructors can quickly see gaps. 
- Preserve existing draft content and author intent while giving a studio-notebook style header for quick uptake. 

### Description
- Added a `## Snapshot` header block to `in-progress/ai-story-society.md`, `in-progress/critical-making-civic-media.md`, and `in-progress/digital-storytelling-data-viz.md` containing `Working title`, `Intended level` (set to `POST_SECONDARY`), `Estimated hours` (45 / 3 credits), `Learning outcomes`, and a `What’s missing` checklist. 
- Learning outcomes were restated in concise, actionable phrasing and a short TODO checklist was added to each file for schedule, deliverables, rubrics, and tooling/partner plans. 
- Left the rest of each draft untouched, preserving the existing sections like `Why`, `Outcomes`, `2-week starter arc`, and `Reading/media`. 

### Testing
- No automated tests were run because these are content-only documentation changes. 
- Basic verification performed by opening each modified file to confirm the `## Snapshot` block appears at the top.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f671bac288325a9d93ad226e4c116)