### PR TITLE
Refine learning pathways tone

### DIFF
--- a/PATHWAYS.md
+++ b/PATHWAYS.md
@@ -1,0 +1,89 @@
+# Learning Pathways (Curated, Loud, and Useful)
+
+This is a **studio‑notebook map** through the Syllabus repo: 3–5 learning arcs that move from **PRIMARY → SECONDARY → POST_SECONDARY**. Each path is a studio ladder: build confidence, build fluency, build agency. Expect the tone to be half studio notebook, half teaching guide—because that’s how real learning actually sticks.
+
+Each pathway below includes:
+- **Intended audience** (grade bands pulled from course READMEs where available)
+- **Duration range** (sessions/weeks from course READMEs where available)
+- A **recommended sequence** across folders with **one‑sentence “why”** and **prereqs**
+- **Direct links** to each course README
+
+---
+
+## 1) Fabrication & Material Truth
+
+**Who it’s for:** Grades **3–5 → 7–9 → 11–12** (as listed in the course READMEs).  
+**Duration range:** **11 weeks × 90 min → 10 weeks (A/B blocks) → 14–16 weeks (semester)**.
+
+**Sequence (PRIMARY → SECONDARY → POST_SECONDARY):**
+1. **PRIMARY:** [3D Printing Course (Grades 3–5)](PRIMARY/3D-Printing-Course-3-5/README.md)  
+   **Why:** Gets students shipping fast, learning the full pipeline from imagination → model → print → iterate without getting lost in tool sprawl.  
+   **Prereqs:** None listed (built for first‑time makers).
+2. **SECONDARY:** [Design for Printability & Function](SECONDARY/Design-for-Printability-and-Function/README.md)  
+   **Why:** Tightens the craft—constraints, tolerances, and functional assemblies turn “cool shapes” into dependable objects.  
+   **Prereqs:** 3D printing foundations (or equivalent).
+3. **POST_SECONDARY:** [Advanced Digital Fabrication Lab — Multi‑Material, Scanning & G‑code Hacks](POST_SECONDARY/Advanced-DigiFab-Lab-Multimaterial-Scanning-Gcode/README.md)  
+   **Why:** Graduates students into lab‑scale thinking: multi‑material workflows, scanning pipelines, and custom G‑code control.  
+   **Prereqs:** Intermediate CAD & 3D printing.
+
+---
+
+## 2) Robotics & Physical Systems (From Play to Piloting)
+
+**Who it’s for:** Grades **3–5 → middle/high school → post‑secondary studio** (based on course READMEs).  
+**Duration range:** **12 weeks × 1 hour → 15 weeks × 1.5 hours → semester‑length studio (see course docs)**.
+
+**Sequence (PRIMARY → SECONDARY → POST_SECONDARY):**
+1. **PRIMARY:** [Scratch Game Design + Cutscenes Lab (Grades 3–5)](PRIMARY/Scratch-Game-Design-Animation_Grades3-5/README.md)  
+   **Why:** Story logic + event‑driven thinking = the clean on‑ramp to robot brains.  
+   **Prereqs:** None listed.
+2. **SECONDARY:** [Robotics → FPV](SECONDARY/Robotics-to-FPV-Course/README.md)  
+   **Why:** Bridges from ground robots to flight systems, adding soldering, voltage control, and real‑world safety.  
+   **Prereqs:** None listed (team‑based, scaffolded).
+3. **POST_SECONDARY:** [Swarm Aesthetics: Perceptual Drift Studio](POST_SECONDARY/swarm_aesthetics/README.md)  
+   **Why:** Pushes robotics into perception, behavior, and emergent systems—less “kit,” more research.  
+   **Prereqs:** Not specified in README (treat as studio‑level with prior coding/robotics comfort).
+
+---
+
+## 3) Sound, Noise, and DIY Instruments
+
+**Who it’s for:** Grades **3–5 → high school → college studio**.  
+**Duration range:** **12 weeks × 1 hour → 22 sessions × 60 min → 14‑week studio/seminar**.
+
+**Sequence (PRIMARY → SECONDARY → POST_SECONDARY):**
+1. **PRIMARY:** [Scratch Game Design + Cutscenes Lab (Grades 3–5)](PRIMARY/Scratch-Game-Design-Animation_Grades3-5/README.md)  
+   **Why:** Timing, mood, and sound cues in Scratch teach the rhythm of narrative—perfect primer before serious audio work.  
+   **Prereqs:** None listed.
+2. **SECONDARY:** [Intro to Sound Design & Engineering](SECONDARY/ExplorationSoundDesign/README.md)  
+   **Why:** Builds real audio fluency: recording, synthesis, editing, and mixing in a mobile‑friendly studio flow.  
+   **Prereqs:** None listed.
+3. **POST_SECONDARY:** [DIY Instrument Lab](POST_SECONDARY/diy-instrument-lab/README.md)  
+   **Why:** Turns students into instrument designers—sound as material, circuit as sculpture, politics as part of the build.  
+   **Prereqs:** Not specified in README (assumes readiness for studio critique and basic tool safety).
+
+---
+
+## 4) Imaging, Story, and Visual Ethics
+
+**Who it’s for:** Grades **3–5 → 6–9 → undergraduate studio**.  
+**Duration range:** **12 weeks × 1 hour → 12 sessions × 90 min → semester‑length studio (see course docs)**.
+
+**Sequence (PRIMARY → SECONDARY → POST_SECONDARY):**
+1. **PRIMARY:** [Scratch Game Design + Cutscenes Lab (Grades 3–5)](PRIMARY/Scratch-Game-Design-Animation_Grades3-5/README.md)  
+   **Why:** Cutscenes = visual storytelling; students learn sequence, framing, and intent before getting technical.  
+   **Prereqs:** None listed.
+2. **SECONDARY:** [Digital Imaging Lab — Level 1](SECONDARY/digital-imaging-lab/README.md)  
+   **Why:** Deep dive into pixels, composition, editing, and ethics—images as craft *and* cultural power.  
+   **Prereqs:** None listed in README.
+3. **POST_SECONDARY:** [Imaging Otherwise](POST_SECONDARY/ImagingOtherwise/README.md)  
+   **Why:** Asks the big questions—who images serve, how pipelines encode bias, and how to build alternatives.  
+   **Prereqs:** Not specified in README (assume studio‑seminar readiness).
+
+---
+
+## Notes for Remixers
+
+- These are **curated defaults**, not rules. Swap in adjacent courses if your lab, staff, or calendar says so.
+- If your students are advanced, **jump levels**—the repo is modular by design.
+- Keep the studio ethic: **show your process, document your mess, teach the why.**


### PR DESCRIPTION
### Motivation
- Remove the exact phrase "punk rock" from the learning pathways copy while preserving the original studio‑notebook / teaching‑guide intent.  
- Soften the voice to emphasize a studio‑notebook ethic and clearer guidance for remixers.  
- Keep the curated sequencing and direct `PRIMARY → SECONDARY → POST_SECONDARY` links and rationale intact.  
- Address inline edit requests to adjust two specific phrasings in `PATHWAYS.md`.

### Description
- Updated `PATHWAYS.md` to change the header sentence from a **punk‑rock map** to a **studio‑notebook map**.  
- Replaced the line `Keep the punk ethic: **show your process, document your mess, teach the why.**` with `Keep the studio ethic: **show your process, document your mess, teach the why.**`.  
- Preserved the rest of the curated pathways content, sequences, links to course `README.md` files, and the final remix notes.  
- Only `PATHWAYS.md` was modified.

### Testing
- This is a documentation‑only change, so no automated test suite was applicable or run.  
- Manually inspected `PATHWAYS.md` to verify the two phrasing changes and that course README links remain present.  
- Local checks confirmed the file renders and content is consistent with the intended studio‑notebook tone.  
- No other files were affected or required testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f671a560c83259ea263219137dcf4)