### PR TITLE
Expand README course links and add new course sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,41 +9,63 @@ A messy, honest archive of courses I've slung across classrooms, studios, and wo
 - **Keep notes scrappy.** I leave space for “local hacks” in most docs. Track your tweaks; future-you (or future-me) will thank you.
 
 ## Course kits — digital fabrication & making
-- [3D-Printing-Course-3-5](./3D-Printing-Course-3-5) – 11-week elementary pipeline from imagination to MakerBot SKETCH queue, complete with print ops, slicer profiles, and empathy-driven capstones.
-- [Design-for-Printability-and-Function](./Design-for-Printability-and-Function) – Intermediate CAD + printability bootcamp for grades 7–9 with OpenSCAD test artifacts, tolerance labs, and data templates for strength tests.
-- [Engineering-Challenges](./Engineering-Challenges) – Mechanism gauntlet (gears, cams, compliant hinges) with print-ready rigs, rubrics, and A/B block lessons targeting measurable performance wins.
-- [Advanced-DigiFab-Lab-Multimaterial-Scanning-Gcode](./Advanced-DigiFab-Lab-Multimaterial-Scanning-Gcode) – Capstone lab where students run a multi-printer fleet, swap filaments mid-job, parse G-code, and process 3D scans like junior techs.
-- [Art-Sculpture-Parametric-3D-Print](./Art-Sculpture-Parametric-3D-Print) – Parametric sculpture studio leaning on OpenSCAD, p5.js, and printer weirdness (vase mode, translucency) to treat rules as art material.
-- [digital_manufacturing](./digital_manufacturing) – 12-session studio weaving CNC, slicing, and CAM literacy with ready-to-run Cubiko G-code, Cura profiles, and printable workflow posters.
-- [MCADArduinoSculpture](./MCADArduinoSculpture) – Local mirror of my Arduino Sculpture syllabus; full build kits and code live in the upstream repo for deeper dives.
+- [3D-Printing-Course-3-5](./PRIMARY/3D-Printing-Course-3-5) – 11-week elementary pipeline from imagination to MakerBot SKETCH queue, complete with print ops, slicer profiles, and empathy-driven capstones.
+- [Design-for-Printability-and-Function](./SECONDARY/Design-for-Printability-and-Function) – Intermediate CAD + printability bootcamp for grades 7–9 with OpenSCAD test artifacts, tolerance labs, and data templates for strength tests.
+- [Engineering-Challenges](./SECONDARY/Engineering-Challenges) – Mechanism gauntlet (gears, cams, compliant hinges) with print-ready rigs, rubrics, and A/B block lessons targeting measurable performance wins.
+- [Advanced-DigiFab-Lab-Multimaterial-Scanning-Gcode](./POST_SECONDARY/Advanced-DigiFab-Lab-Multimaterial-Scanning-Gcode) – Capstone lab where students run a multi-printer fleet, swap filaments mid-job, parse G-code, and process 3D scans like junior techs.
+- [Art-Sculpture-Parametric-3D-Print](./POST_SECONDARY/Art-Sculpture-Parametric-3D-Print) – Parametric sculpture studio leaning on OpenSCAD, p5.js, and printer weirdness (vase mode, translucency) to treat rules as art material.
+- [digital_manufacturing](./SECONDARY/digital_manufacturing) – 12-session studio weaving CNC, slicing, and CAM literacy with ready-to-run Cubiko G-code, Cura profiles, and printable workflow posters.
+- [MCADArduinoSculpture](./POST_SECONDARY/MCADArduinoSculpture) – Local mirror of my Arduino Sculpture syllabus; full build kits and code live in the upstream repo for deeper dives.
 
 ## Course kits — robotics, flight & control
-- [Robotics-to-FPV-Course](./Robotics-to-FPV-Course) – 15-week bridge from Arduino ground robots to sub-250 g FPV whoops, with BOMs, flight checklists, and simulator drills to keep teams flying smart.
-- [HS_Drone_Racing_League](./HS_Drone_Racing_League) – League starter kit covering safety law, bootcamp schedules, forms, and sim training for school-based FPV crews.
-- [TinyWhoop-Workshop](./TinyWhoop-Workshop) – Four-session Betaflight configurator workshop emphasizing safe habits, backups, and tuning tiny whoops until they feel personal.
-- [Robotics_HS_SpikePrime](./Robotics_HS_SpikePrime) – Compact 12-hour Spike Prime primer with `.md` and `.pdf` guides for quick-start robotics programs.
-- [robotic-vibes](./robotic-vibes) – Expanding course family built on a robotics + vibe coding level 1 spine, offering LEGO Spike, Arduino, and CircuitPython dialects with reproducible build docs and assessment kits.
+- [Robotics-to-FPV-Course](./SECONDARY/Robotics-to-FPV-Course) – 15-week bridge from Arduino ground robots to sub-250 g FPV whoops, with BOMs, flight checklists, and simulator drills to keep teams flying smart.
+- [HS_Drone_Racing_League](./SECONDARY/HS_Drone_Racing_League) – League starter kit covering safety law, bootcamp schedules, forms, and sim training for school-based FPV crews.
+- [TinyWhoop-Workshop](./SECONDARY/TinyWhoop-Workshop) – Four-session Betaflight configurator workshop emphasizing safe habits, backups, and tuning tiny whoops until they feel personal.
+- [Robotics_HS_SpikePrime](./SECONDARY/Robotics_HS_SpikePrime) – Compact 12-hour Spike Prime primer with `.md` and `.pdf` guides for quick-start robotics programs.
+- [robotic-vibes](./SECONDARY/robotic-vibes) – Expanding course family built on a robotics + vibe coding level 1 spine, offering LEGO Spike, Arduino, and CircuitPython dialects with reproducible build docs and assessment kits.
 
 ## Course kits — sound, media & critical listening
-- [CTMSoundDesign](./CTMSoundDesign) – Quick-start cue sheets, reflections, and a compact eight-session syllabus anchored in making, rehearsing, and critiquing sound cues for theater.
-- [ExplorationSoundDesign](./ExplorationSoundDesign) – 22-day Chromebook-friendly sound design adventure with BandLab station cards, lessons, and assessments built for mobile-first classrooms.
-- [Digital-Music-Control](./Digital-Music-Control) – MOARkNOBS-inspired MIDI controller curriculum across maker vs. studio tracks, guiding learners from Arduino blinks to firmware architecture and performance UX.
-- [SoundSystemsSociety](./SoundSystemsSociety) – College-level seminar where PA systems meet politics, complete with assignments, listening logs, and instructor notes for power-aware sound practice.
+- [CTMSoundDesign](./PRIMARY/CTMSoundDesign) – Quick-start cue sheets, reflections, and a compact eight-session syllabus anchored in making, rehearsing, and critiquing sound cues for theater.
+- [ExplorationSoundDesign](./SECONDARY/ExplorationSoundDesign) – 22-day Chromebook-friendly sound design adventure with BandLab station cards, lessons, and assessments built for mobile-first classrooms.
+- [Digital-Music-Control](./SECONDARY/Digital-Music-Control) – MOARkNOBS-inspired MIDI controller curriculum across maker vs. studio tracks, guiding learners from Arduino blinks to firmware architecture and performance UX.
+- [lofi-beats-hs](./SECONDARY/lofi-beats-hs) – Lo-fi beat lab for high schoolers who want to turn broken rooms and stairwells into reverb units and mood machines.
+- [SoundSystemsSociety](./POST_SECONDARY/SoundSystemsSociety) – College-level seminar where PA systems meet politics, complete with assignments, listening logs, and instructor notes for power-aware sound practice.
+- [stringfield-studio-hs](./SECONDARY/stringfield-studio-hs) – Physical sound drawing studio that makes gesture visible and audible through string rigs, recording, and compositional sketches.
 
 ## Course kits — imaging, media art & storytelling
-- [digital-imaging-lab](./digital-imaging-lab) – Middle/early high school imaging lab treating pixels as craft and inquiry, with session plans, anchor projects, rubrics, and ethics resources.
-- [ImagingOtherwise](./ImagingOtherwise) – Undergraduate studio-seminar challenging visual defaults through speculative imaging assignments, readings, and instructor pacing notes.
-- [MCADMedia1](./MCADMedia1) – Foundation media archive stuffed with assignment sheets, camera cheats, and pandemic-era pedagogy reflections for remixing first-year experiences.
-- [MCADMedia2](./MCADMedia2) – Sequel course docs spanning experimental media briefs, modular synth cheat sheets, and p5.js explainers to push students past polite work.
+- [digital-imaging-lab](./SECONDARY/digital-imaging-lab) – Middle/early high school imaging lab treating pixels as craft and inquiry, with session plans, anchor projects, rubrics, and ethics resources.
+- [ImagingOtherwise](./POST_SECONDARY/ImagingOtherwise) – Undergraduate studio-seminar challenging visual defaults through speculative imaging assignments, readings, and instructor pacing notes.
+- [MCADMedia1](./POST_SECONDARY/MCADMedia1) – Foundation media archive stuffed with assignment sheets, camera cheats, and pandemic-era pedagogy reflections for remixing first-year experiences.
+- [MCADMedia2](./POST_SECONDARY/MCADMedia2) – Sequel course docs spanning experimental media briefs, modular synth cheat sheets, and p5.js explainers to push students past polite work.
+
+## Course kits — game dev, sensing & interaction
+- [Scratch-Game-Design-Animation_Grades3-5](./PRIMARY/Scratch-Game-Design-Animation_Grades3-5) – Elementary Scratch studio that pushes cutscenes, level pacing, and storytelling through animated game builds.
+- [hs-game-tech-intro](./SECONDARY/hs-game-tech-intro) – Short-form Scratch + micro:bit intro for high schoolers, built for low-stakes, high-momentum coding labs.
+- [sensing-and-gesture](./SECONDARY/sensing-and-gesture) – College studio/seminar on embodied sensing and gesture systems with instructor notes and ethics scaffolds.
+- [diy-instrument-lab](./POST_SECONDARY/diy-instrument-lab) – 14-week instrument-building studio for found objects, contact mics, and sound politics.
+- [swarm_aesthetics](./POST_SECONDARY/swarm_aesthetics) – Perceptual drift studio skeleton with schedules, session stubs, and a loud invitation to remix.
 
 ## Workshops, briefs & experiments
-- [diy-local-ai-workshop](./diy-local-ai-workshop) – Three-hour agency-first workshop guiding adults through local LLM installs, tooling choices, and prompt boundaries they can defend.
+- [diy-local-ai-workshop](./SECONDARY/diy-local-ai-workshop) – Three-hour agency-first workshop guiding adults through local LLM installs, tooling choices, and prompt boundaries they can defend.
+- [tms-limiter-workshop](./POST_SECONDARY/tms-limiter-workshop) – Compact limiter workshop kit with slides and listening notes for quick signal-flow demos.
+
+## AE Modular micro-workshops (solderless chaos, intentional outcomes)
+- [choir-divider](./AE/choir-divider) – CMOS clock divider lab for turning one pulse into a choir of rhythmic voices.
+- [crushing-time-lab](./AE/crushing-time-lab) – Sample-rate reducer build that turns clean signals into crunchy artifacts.
+- [fold-and-fire](./AE/fold-and-fire) – Distortion + gate extraction workshop built for patch-happy noise sculptors.
+- [gates-from-gravity](./AE/gates-from-gravity) – Window comparator build that converts CV into playable gate logic.
+- [switch-orchard](./AE/switch-orchard) – CD4051 routing lab for manual or scanned patch selection.
+
+## In-progress briefs (prototype notes, not full syllabi yet)
+- [ai-story-society](./in-progress/ai-story-society.md) – Early brief on co-writing with AI and mapping narrative power.
+- [critical-making-civic-media](./in-progress/critical-making-civic-media.md) – Draft studio-seminar about making as civic intervention.
+- [digital-storytelling-data-viz](./in-progress/digital-storytelling-data-viz.md) – Sketch brief for data storytelling with access-minded publishing.
 
 > Want to braid sound and control? Start with **Digital-Music-Control** and riff into **CTMSoundDesign** or **ExplorationSoundDesign**—the sections above spell out how.
 
 ## Legacy docs & loose artifacts
-- [MPS_comEd](./MPS_comEd) – Early community education lesson plans and class descriptions straight from the archives—expect `.docx` time capsules.
-- [SMM](./SMM) – Miscellaneous workshop docs like chain-reaction mini builds and digital photo briefs from past programs.
+- [MPS_comEd](./PRIMARY/MPS_comEd) – Early community education lesson plans and class descriptions straight from the archives—expect `.docx` time capsules.
+- [SMM](./PRIMARY/SMM) – Miscellaneous workshop docs like chain-reaction mini builds and digital photo briefs from past programs.
 
 ## Meta: indexing, validation & data
 - [catalog](./catalog) – JSON index + schema pairing for folks who want to surface these courses in another system; validate before you broadcast.


### PR DESCRIPTION
### Motivation
- Fix root `README.md` links that pointed to top-level paths and align them with the actual folder layout under `PRIMARY`, `SECONDARY`, `POST_SECONDARY`, `AE`, and `in-progress`.
- Surface missing course kits and micro-workshops so the README accurately reflects the repository contents and teaching intent.
- Preserve the half-studio-notebook, half-teaching-guide voice while making navigation explicit and less error-prone.
- Reduce confusion and dead paths for users browsing course materials.

### Description
- Updated `README.md` to prepend directory prefixes for many entries (e.g., `PRIMARY/`, `SECONDARY/`, `POST_SECONDARY/`, `AE/`, `in-progress/`) so links map to actual folders.
- Added new sections and entries for "Course kits — game dev, sensing & interaction", "AE Modular micro-workshops", and "In-progress briefs" with compact, teaching-forward descriptions.
- Introduced specific course links such as `lofi-beats-hs`, `stringfield-studio-hs`, `Scratch-Game-Design-Animation_Grades3-5`, and several AE workshop entries, and moved legacy docs under `PRIMARY/` where appropriate.
- Kept existing course descriptions intact and limited edits to link targets, section additions, and minor reordering.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f6aa469d88325a057029fe3106844)